### PR TITLE
Add tests and travis-ci testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.log
 *.pyc
 __pycache__/
+.cache/
+.coverage
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# http://travis-ci.org/#!/jupyter/jupyterhub
+language: python
+sudo: false
+python:
+    - 3.5
+    - 3.4
+    - 3.3
+env:
+    - JHUB_VER=0.5.0
+    - JHUB_VER=0.6.1
+matrix:
+    include:
+    - python: 3.5
+      env: JHUB_VER=master
+
+before_install:
+    - npm install -g configurable-http-proxy
+    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
+    - git clone --quiet --branch $JHUB_VER https://github.com/jupyter/jupyterhub.git jupyterhub
+install:
+    - pip install --pre -f travis-wheels/wheelhouse -r jupyterhub/dev-requirements.txt .
+    - pip install --pre -e jupyterhub
+script:
+    - travis_retry py.test --cov batchspawner batchspawner/tests -v
+#after_success:
+#    - codecov
+# matrix:
+#   include:
+#     - python: 3.5
+#       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://127.0.0.1.xip.io:8000

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - pip install --pre -f travis-wheels/wheelhouse -r jupyterhub/dev-requirements.txt .
     - pip install --pre -e jupyterhub
 script:
-    - travis_retry py.test --cov batchspawner batchspawner/tests -v
+    - travis_retry py.test --lf --cov batchspawner batchspawner/tests -v
 #after_success:
 #    - codecov
 # matrix:

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -25,6 +25,7 @@ import xml.etree.ElementTree as ET
 
 from tornado import gen
 from tornado.process import Subprocess
+from tornado.iostream import StreamClosedError
 
 from jupyterhub.spawner import Spawner
 from traitlets import (
@@ -40,7 +41,11 @@ def run_command(cmd, input=None, env=None):
     inbytes = None
     if input:
         inbytes = input.encode()
-        yield proc.stdin.write(inbytes)
+        try:
+            yield proc.stdin.write(inbytes)
+        except StreamClosedError as exp:
+            # Apparently harmless
+            pass
     proc.stdin.close()
     out = yield proc.stdout.read_until_close()
     proc.stdout.close()

--- a/batchspawner/tests/conftest.py
+++ b/batchspawner/tests/conftest.py
@@ -1,0 +1,3 @@
+"""py.test fixtures imported from Jupyterhub testing"""
+
+from jupyterhub.tests.conftest import *

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -1,0 +1,71 @@
+"""Test BatchSpawner and subclasses"""
+
+from unittest import mock
+from .. import BatchSpawnerRegexStates
+from traitlets import Unicode
+import time
+import sys
+import pytest
+from jupyterhub import orm
+
+class BatchDummy(BatchSpawnerRegexStates):
+    batch_submit_cmd = Unicode('echo 12345')
+    batch_query_cmd = Unicode('echo RUN userhost123')
+    batch_cancel_cmd = Unicode('echo STOP')
+    batch_script = Unicode('{cmd}')
+    state_pending_re = Unicode('PEND')
+    state_running_re = Unicode('RUN')
+    state_exechost_re = Unicode('RUN (.*)$')
+
+_echo_sleep = """
+import sys, time
+print(sys.argv)
+time.sleep(30)
+"""
+
+def new_spawner(db, **kwargs):
+    kwargs.setdefault('cmd', [sys.executable, '-c', _echo_sleep])
+    kwargs.setdefault('user', db.query(orm.User).first())
+    kwargs.setdefault('hub', db.query(orm.Hub).first())
+    kwargs.setdefault('INTERRUPT_TIMEOUT', 1)
+    kwargs.setdefault('TERM_TIMEOUT', 1)
+    kwargs.setdefault('KILL_TIMEOUT', 1)
+    kwargs.setdefault('poll_interval', 1)
+    return BatchDummy(db=db, **kwargs)
+
+def test_spawner(db, io_loop):
+    spawner = new_spawner(db=db)
+
+    status = io_loop.run_sync(spawner.poll)
+    assert status == 1
+    assert spawner.job_id == ''
+
+    io_loop.run_sync(spawner.start)
+    assert spawner.user.server.ip == 'userhost123'
+    assert spawner.job_id == '12345'
+    
+    time.sleep(0.2)
+    
+    status = io_loop.run_sync(spawner.poll)
+    assert status is None
+    spawner.batch_query_cmd = 'echo NOPE'
+    io_loop.run_sync(spawner.stop)
+    status = io_loop.run_sync(spawner.poll)
+    assert status == 1
+    
+def test_submit_failure(db, io_loop):
+    spawner = new_spawner(db=db)
+    spawner.batch_submit_cmd = 'true'
+    with pytest.raises(AssertionError):
+        io_loop.run_sync(spawner.start)
+    assert spawner.job_id == ''
+    assert spawner.job_status == ''
+
+def test_pending_fails(db, io_loop):
+    spawner = new_spawner(db=db)
+    spawner.batch_query_cmd = 'echo xyz'
+    with pytest.raises(AssertionError):
+        io_loop.run_sync(spawner.start)
+    assert spawner.job_id == ''
+    assert spawner.job_status == ''
+


### PR DESCRIPTION
Note this is still a first pass at implementing testing -- only the core functionality of the batchspawner base class is exercised. Integration tests for the WrapSpawner are still needed, since that is probably more sensitive to small changes in the interaction between the Hub and Spawner.