### PR TITLE
Add support for the HTCondor batch system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package also includes WrapSpawner and ProfilesSpawner, which provide mechan
 ###Overview
 
 This file contains an abstraction layer for batch job queueing systems (`BatchSpawnerBase`), and implements
-Jupyterhub spawners for Torque, SLURM, SGE, and eventually others.
+Jupyterhub spawners for Torque, SLURM, SGE, HTCondor and eventually others.
 Common attributes of batch submission / resource manager environments will include notions of:
   * queue names, resource manager addresses
   * resource limits including runtime, number of processes, memory

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -515,6 +515,7 @@ Output = {homedir}/.jupyterhub.condor.out
 Error = {homedir}/.jupyterhub.condor.err
 ShouldTransferFiles = False
 GetEnv = True
+{options}
 Queue
 """,
         config=True)

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -504,4 +504,38 @@ class GridengineSpawner(BatchSpawnerBase):
         self.log.error("Spawner unable to match host addr in job {0} with status {1}".format(self.job_id, self.job_status))
         return
 
+class CondorSpawner(BatchSpawnerRegexStates):
+    batch_script = Unicode("""
+Executable = /bin/sh
+RequestMemory = {memory}
+RequestCpus = {nprocs}
+Arguments = \"-c 'exec {cmd}'\"
+Remote_Initialdir = {homedir}
+Output = {homedir}/.jupyterhub.condor.out
+Error = {homedir}/.jupyterhub.condor.err
+ShouldTransferFiles = False
+GetEnv = True
+Queue
+""",
+        config=True)
+
+    # outputs job id string
+    batch_submit_cmd = Unicode('sudo -E -u {username} condor_submit', config=True)
+    # outputs job data XML string
+    batch_query_cmd = Unicode('condor_q {job_id} -format "%s, " JobStatus -format "%s" RemoteHost -format "\n" True', config=True)
+    batch_cancel_cmd = Unicode('sudo -E -u {username} condor_rm {job_id}', config=True)
+    # job status: 1 = pending, 2 = running
+    state_pending_re = Unicode(r'^1,', config=True)
+    state_running_re = Unicode(r'^2,', config=True)
+    state_exechost_re = Unicode(r'^\w*, .*@([^ ]*)', config=True)
+
+    def parse_job_id(self, output):
+        match = re.search(r'.*submitted to cluster ([0-9]+)', output)
+        if match:
+            return match.groups()[0]
+
+        error_msg = "CondorSpawner unable to parse jobID from text: " + output
+        self.log.error(error_msg)
+        raise Exception(error_msg)
+
 # vim: set ai expandtab softtabstop=4:


### PR DESCRIPTION
One thing that could be improved with this initial support for condor is that if req_nprocs or req_memory are not configured, job submission fails, because the statements defining RequestMemory and RequestCpus are malformed.  It would be nice to omit these statements if the corresponding variable is empty or provide reasonable defaults.

Does this problem affect the other batch systems as well?  If so, perhaps we can have a common solution.