### PR TITLE
Add return statement to BatchSpawner.start

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -297,6 +297,8 @@ class BatchSpawnerBase(Spawner):
                         self.job_id, self.user.server.ip, self.user.server.port)
             )
 
+        return self.user.server.ip, self.user.server.port
+
     @gen.coroutine
     def stop(self, now=False):
         """Stop the singleuser server job.


### PR DESCRIPTION
Since Jupyterhub 0.7, start method should "Return ip, port instead of setting on self.user.server directly." [1].

[1] https://github.com/jupyterhub/jupyterhub/blob/d44ee4b8fa45cde12c764fffd34ff17ad34c590e/jupyterhub/spawner.py#L519