### PR TITLE
Moved run_command into the BatchSpawnerBase class

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -35,26 +35,6 @@ from traitlets import (
 from jupyterhub.utils import random_port
 from jupyterhub.spawner import set_user_setuid
 
-@gen.coroutine
-def run_command(cmd, input=None, env=None):
-    proc = Subprocess(cmd, shell=True, env=env, stdin=Subprocess.STREAM, stdout=Subprocess.STREAM)
-    inbytes = None
-    if input:
-        inbytes = input.encode()
-        try:
-            yield proc.stdin.write(inbytes)
-        except StreamClosedError as exp:
-            # Apparently harmless
-            pass
-    proc.stdin.close()
-    out = yield proc.stdout.read_until_close()
-    proc.stdout.close()
-    err = yield proc.wait_for_exit()
-    if err != 0:
-        return err # exit error?
-    else:
-        out = out.decode().strip()
-        return out
 
 class BatchSpawnerBase(Spawner):
     """Base class for spawners using resource manager batch job submission mechanisms
@@ -153,6 +133,27 @@ class BatchSpawnerBase(Spawner):
         return ' '.join(self.cmd + self.get_args())
 
     @gen.coroutine
+    def run_command(self, cmd, input=None, env=None):
+        proc = Subprocess(cmd, shell=True, env=env, stdin=Subprocess.STREAM, stdout=Subprocess.STREAM)
+        inbytes = None
+        if input:
+            inbytes = input.encode()
+            try:
+                yield proc.stdin.write(inbytes)
+            except StreamClosedError as exp:
+                # Apparently harmless
+                pass
+        proc.stdin.close()
+        out = yield proc.stdout.read_until_close()
+        proc.stdout.close()
+        err = yield proc.wait_for_exit()
+        if err != 0:
+            return err # exit error?
+        else:
+            out = out.decode().strip()
+            return out
+
+    @gen.coroutine
     def submit_batch_script(self):
         subvars = self.get_req_subvars()
         cmd = self.batch_submit_cmd.format(**subvars)
@@ -162,7 +163,7 @@ class BatchSpawnerBase(Spawner):
         script = self.batch_script.format(**subvars)
         self.log.info('Spawner submitting job using ' + cmd)
         self.log.info('Spawner submitted script:\n' + script)
-        out = yield run_command(cmd, input=script, env=self.get_env())
+        out = yield self.run_command(cmd, input=script, env=self.get_env())
         try:
             self.log.info('Job submitted. cmd: ' + cmd + ' output: ' + out)
             self.job_id = self.parse_job_id(out)
@@ -188,7 +189,7 @@ class BatchSpawnerBase(Spawner):
         cmd = self.batch_query_cmd.format(**subvars)
         self.log.debug('Spawner querying job: ' + cmd)
         try:
-            out = yield run_command(cmd)
+            out = yield self.run_command(cmd)
             self.job_status = out
         except Exception as e:
             self.log.error('Error querying job ' + self.job_id)
@@ -206,7 +207,7 @@ class BatchSpawnerBase(Spawner):
         subvars['job_id'] = self.job_id
         cmd = self.batch_cancel_cmd.format(**subvars)
         self.log.info('Cancelling job ' + self.job_id + ': ' + cmd)
-        yield run_command(cmd)
+        yield self.run_command(cmd)
 
     def load_state(self, state):
         """load job_id from state"""


### PR DESCRIPTION
Moving the `run_command` function into the `BatchSpawnerBase` class allows the functionality to be overridden by sub classes. For example, a subclass could SSH into a remote server to run the commands instead of locally on the machine.