### PR TITLE
merge user_options dict with subvars

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -161,7 +161,7 @@ class BatchSpawnerBase(Spawner):
         cmd = self.batch_submit_cmd.format(**subvars)
         subvars['cmd'] = self.cmd_formatted_for_batch()
         if hasattr(self, 'user_options'):
-            subvars['user_options'] = self.user_options
+            subvars.update(self.user_options)
         script = self.batch_script.format(**subvars)
         self.log.info('Spawner submitting job using ' + cmd)
         self.log.info('Spawner submitted script:\n' + script)


### PR DESCRIPTION
otherwise the `user_options` dictionary is nested inside the `subvars["user_options"]` value and cannot be used easily in the batch script