### PR TITLE
Allow for the ability to launch on multiple Slurm clusters

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -464,7 +464,7 @@ which jupyterhub-singleuser
     # outputs line like "Submitted batch job 209"
     batch_submit_cmd = Unicode('sudo -E -u {username} sbatch --parsable').tag(config=True)
     # outputs status and exec node like "RUNNING hostname"
-    batch_query_cmd = Unicode('sudo -E -u {username} squeue -h -j {job_id} -o "%T %B"').tag(config=True) #
+    batch_query_cmd = Unicode("sudo -E -u {username} squeue -h -j {job_id} -o '%T %B'").tag(config=True) #
     batch_cancel_cmd = Unicode('sudo -E -u {username} scancel {job_id}').tag(config=True)
     # use long-form states: PENDING,  CONFIGURING = pending
     #  RUNNING,  COMPLETING = running

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -434,6 +434,10 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
     """A Spawner that just uses Popen to start local processes."""
 
     # all these req_foo traits will be available as substvars for templated strings
+    req_cluster = Unicode('', \
+        help="Cluster name to submit job to resource manager"
+        ).tag(config=True)
+
     req_partition = Unicode('', \
         help="Partition name to submit job to resource manager"
         ).tag(config=True)
@@ -471,7 +475,7 @@ which jupyterhub-singleuser
     def parse_job_id(self, output):
         # make sure jobid is really a number
         try:
-            id = output.split(' ')[-1]
+            id = output.split(' ')[3]
             int(id)
         except Exception as e:
             self.log.error("SlurmSpawner unable to parse job ID from text: " + output)

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -462,7 +462,7 @@ which jupyterhub-singleuser
 {cmd}
 """).tag(config=True)
     # outputs line like "Submitted batch job 209"
-    batch_submit_cmd = Unicode('sudo -E -u {username} sbatch').tag(config=True)
+    batch_submit_cmd = Unicode('sudo -E -u {username} sbatch --parsable').tag(config=True)
     # outputs status and exec node like "RUNNING hostname"
     batch_query_cmd = Unicode('sudo -E -u {username} squeue -h -j {job_id} -o "%T %B"').tag(config=True) #
     batch_cancel_cmd = Unicode('sudo -E -u {username} scancel {job_id}').tag(config=True)
@@ -475,7 +475,7 @@ which jupyterhub-singleuser
     def parse_job_id(self, output):
         # make sure jobid is really a number
         try:
-            id = output.split(' ')[3]
+            id = output.split(';')[0]
             int(id)
         except Exception as e:
             self.log.error("SlurmSpawner unable to parse job ID from text: " + output)


### PR DESCRIPTION
Simple pull request to launch jupyter jobs on different Slurm clusters. The configuration can all be completed with `jupyterhub_config.py`.

### Observation: 

When dealing with clusters, these lines break `state_ispending` & `state_isrunning`:

```python
state_pending_re = Unicode(r'^(?:PENDING|CONFIGURING)').tag(config=True)
state_running_re = Unicode(r'^(?:RUNNING|COMPLETING)').tag(config=True)
```

The beginning of line character breaks clusters capability because queries print a leading line. Is this there for a reason? It can probably be safely removed.

### Configuration Example

```python
c.SlurmSpawner.batch_query_cmd = 'sudo -E -u {username} squeue -M {cluster} -h -j {job_id} -o "%T %B"'
c.SlurmSpawner.batch_cancel_cmd = 'sudo -E -u {username} scancel -M {cluster} {job_id}'
c.SlurmSpawner.state_pending_re = r'(?:PENDING|CONFIGURING)'
c.SlurmSpawner.state_running_re = r'(?:RUNNING|COMPLETING)'

#...

c.ProfilesSpawner.profiles = [
        ("Host Process", 'local', 'jupyterhub.spawner.LocalProcessSpawner', {'ip':'0.0.0.0'}),
        ("SMP - 1 core, 3 hours", 'smp1c3h', 'batchspawner.SlurmSpawner',
            dict(req_runtime = '3:00:00', req_cluster = 'smp', req_partition = 'smp')),
        ("GTX 1080 - 1 gpu, 3 hours", 'gtx10801c1g3h', 'batchspawner.SlurmSpawner',
            dict(req_runtime = '3:00:00', req_cluster = 'gpu', req_partition = 'gtx1080', req_options = '--gres=gpu:1')),
]
```