### PR TITLE
Select singleserver port number on remote host

### DIFF
--- a/batchspawner/__init__.py
+++ b/batchspawner/__init__.py
@@ -1,1 +1,3 @@
 from .batchspawner import *
+from . import singleuser
+from . import api

--- a/batchspawner/__init__.py
+++ b/batchspawner/__init__.py
@@ -1,3 +1,2 @@
 from .batchspawner import *
-from . import singleuser
 from . import api

--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -1,0 +1,17 @@
+import json
+from tornado import web
+from jupyterhub.apihandlers import  APIHandler, default_handlers
+
+class BatchSpawnerAPIHandler(APIHandler):
+    @web.authenticated
+    def post(self):
+        """POST set user's spawner port number"""
+        user = self.get_current_user()
+        data = self.get_json_body()
+        if user.spawner.port == 0:
+            port = data.get('port', 0)
+            user.spawner.port = int(port)
+        self.finish(json.dumps({"message": "BatchSpawner port configured"}))
+        self.set_status(201)
+
+default_handlers.append((r"/api/batchspawner", BatchSpawnerAPIHandler))

--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -8,9 +8,8 @@ class BatchSpawnerAPIHandler(APIHandler):
         """POST set user's spawner port number"""
         user = self.get_current_user()
         data = self.get_json_body()
-        if user.spawner.port == 0:
-            port = data.get('port', 0)
-            user.spawner.port = int(port)
+        port = int(data.get('port', 0))
+        user.spawner.current_port = port
         self.finish(json.dumps({"message": "BatchSpawner port configured"}))
         self.set_status(201)
 

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -29,6 +29,7 @@ from subprocess import CalledProcessError
 from tornado.iostream import StreamClosedError
 
 from jupyterhub.spawner import Spawner
+from jupyterhub.traitlets import Command
 from traitlets import (
     Integer, Unicode, Float, Dict, default
 )
@@ -72,6 +73,9 @@ class BatchSpawnerBase(Spawner):
         state_isrunning
         state_gethost
     """
+
+    # override default since will need to set the listening port using the api
+    cmd = Command(['batchspawner-singleuser'], allow_none=True).tag(config=True)
 
     # override default since batch systems typically need longer
     start_timeout = Integer(300).tag(config=True)
@@ -342,14 +346,7 @@ class BatchSpawnerBase(Spawner):
     @gen.coroutine
     def start(self):
         """Start the process"""
-        if self.user and self.user.server and self.user.server.port:
-            self.port = self.user.server.port
-            self.db.commit()
-        elif (jupyterhub.version_info < (0,7) and not self.user.server.port) or (
-             jupyterhub.version_info >= (0,7) and not self.port
-        ):
-            self.port = random_port()
-            self.db.commit()
+        self.port = self.server.port = 0
         job = yield self.submit_batch_script()
 
         # We are called with a timeout, and if the timeout expires this function will
@@ -374,6 +371,9 @@ class BatchSpawnerBase(Spawner):
             yield gen.sleep(self.startup_poll_interval)
 
         self.current_ip = self.state_gethost()
+        while self.port == 0:
+            yield gen.sleep(self.startup_poll_interval)
+
         if jupyterhub.version_info < (0,7):
             # store on user for pre-jupyterhub-0.7:
             self.user.server.port = self.port

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -349,7 +349,7 @@ class BatchSpawnerBase(Spawner):
     @gen.coroutine
     def start(self):
         """Start the process"""
-        if self.server:
+        if jupyterhub.version_info >= (0,8) and self.server:
             self.server.port = self.port
 
         job = yield self.submit_batch_script()

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,0 +1,21 @@
+from jupyterhub.singleuser import SingleUserNotebookApp
+from jupyterhub.utils import random_port, url_path_join
+from traitlets import default
+
+class BatchSingleUserNotebookApp(SingleUserNotebookApp):
+    @default('port')
+    def _port(self):
+        return random_port()
+
+    def start(self):
+        # Send Notebook app's port number to remote Spawner
+        self.hub_auth._api_request(method='POST',
+                                   url=url_path_join(self.hub_api_url, 'batchspawner'),
+                                   json={'port' : self.port})
+        super().start()
+
+def main(argv=None):
+    return BatchSingleUserNotebookApp.launch_instance(argv)
+
+if __name__ == "__main__":
+    main()

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -17,6 +17,7 @@ except:
 
 testhost = "userhost123"
 testjob  = "12345"
+testport = 54321
 
 class BatchDummy(BatchSpawnerRegexStates):
     exec_prefix = ''
@@ -61,6 +62,7 @@ def new_spawner(db, spawner_class=BatchDummy, **kwargs):
         user = User(user, {})
     kwargs.setdefault('hub', hub)
     kwargs.setdefault('user', user)
+    kwargs.setdefault('current_port', testport)
     kwargs.setdefault('INTERRUPT_TIMEOUT', 1)
     kwargs.setdefault('TERM_TIMEOUT', 1)
     kwargs.setdefault('KILL_TIMEOUT', 1)

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -10,7 +10,7 @@ from jupyterhub import orm, version_info
 from tornado import gen
 
 try:
-    from jupyterhub.objects import Hub
+    from jupyterhub.objects import Hub, Server
     from jupyterhub.user import User
 except:
     pass
@@ -60,6 +60,8 @@ def new_spawner(db, spawner_class=BatchDummy, **kwargs):
     else:
         hub = Hub()
         user = User(user, {})
+        server = Server()
+        kwargs.setdefault('server', server)
     kwargs.setdefault('hub', hub)
     kwargs.setdefault('user', user)
     kwargs.setdefault('current_port', testport)

--- a/scripts/batchspawner-singleuser
+++ b/scripts/batchspawner-singleuser
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from batchspawner.singleuser import main
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 from setuptools import setup
+from glob import glob
 
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))
@@ -28,6 +29,7 @@ with open(pjoin(here, 'README.md'), encoding='utf-8') as f:
 
 setup_args = dict(
     name                = 'batchspawner',
+    scripts             = glob(pjoin('scripts', '*')),
     packages            = ['batchspawner'],
     version             = version_ns['__version__'],
     description         = """Batchspawner: A spawner for Jupyterhub to spawn notebooks using batch resource managers.""",


### PR DESCRIPTION
**Context**

We provide compute nodes on our GPU cluster for a graduate deep learning course through JupyterHub and BatchSpawner. The nodes are available two hours a week under a reservation for the course (a lab period). Each node has 8 GPUs, a student is allocated one GPU and there are around 30 students running Notebook at the same time. Therefore, multiple jupyterhub-singleserver can run on a single compute node. Until last week, it was working flawlessly.

**Problem**

During last week lab period, two users reported being unable to connect to their notebook. After inspecting their notebook log, I found this message:

> [I 2018-02-16 10:26:57.826 SingleUserNotebookApp notebookapp:1191] The port 58824 is already in use, trying another port.
> [C 2018-02-16 10:26:57.826 SingleUserNotebookApp notebookapp:1203] ERROR: the notebook server could not be started because no available port could be found.

The users could not access their notebook, because the singleserver could not start. The singleserver could not start because it was assigned a port number that was already used on the compute, probable by another singleserver used by another student.

The port generation for the singleserver is done on the BatchSpawner side ([batchpawner.py:272-278](https://github.com/jupyterhub/batchspawner/blob/master/batchspawner/batchspawner.py#L272)). The function used to generate the random port is [`jupyterhub.utils.random_port`](https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/utils.py#L22). The function content is reproduced here to help understanding the issue: 
```Python
def random_port():
    """Get a single random port."""
    sock = socket.socket()
    sock.bind(('', 0))
    port = sock.getsockname()[1]
    sock.close()
    return port
```
`random_port` create a socket locally, on the Hub/Spawner side, retrieves the port number and close the socket. Once the function has closed the socket, the port number is available again since nothing on the Hub side is bound to it and `random_port` could return the same port number when called again. The randomness of the function depends on the kernel handling of ephemeral port numbers. Furthermore, the function is only for **local** ports. There is no guarantee that an ephemeral port available for the Hub will be available for the compute and this the main issue with using this function to set the remote singleserver port.

**Solution**

Our team brainstormed on possible solutions that were looking at limiting the risk of port number collisions : hashing the job id, increasing the range from ephemeral port to all user available ports, etc, but they all had the same problem : it meant deciding of the port number on the Hub side, thus having no guarantee this port would be available on the compute and risking a job failure. We concluded that the singleserver port has to be selected remotely and sent back to the Hub/Spawner.

This PR fixes the port generation issue by letting the port number being generated by the singleserver and sent it back to the BatchSpawner through a BSD socket. The BSD socket address and port are provided to the singleserver by command-line arguments in the job script. To add the command-line arguments and the port syncing, this PR implements a batchspawner-singleserver script and app that inherits from SingleUserNotebookApp.

The port number is received by the spawner on the created socket before `BatchSpawner.start` returns.

This solution has proven effective to solve our port number collision.

**Issue with PR solution**

Using a socket to communicate between the Spawner/Hub and the Notebook singleserver is not very _jupyter-like_. It works for our use case, but could be problematic when working in an environment where there is a firewall between the compute nodes and the Hub, since we use a random port number to communicate between the compute node and the Spawner.

There is also no validation that the data received by the Spawner is truly a port number sent by the right compute node.

Ideally, I think the selected port should be communicated back to the Hub through the REST API, but I am uncertain of what it implies and how to properly implement it. Therefore, I think this PR should be accepted as is, but it should be used as the beginning of a solution to the aforementioned problem. I am willing to implement the right solution once we have converged on the proper way to do it.


