### PR TITLE
Fix testing versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       env: JHUB_VER=master
     exclude:
     - python: 3.3
-      env: JHUB_VER=0.8.0
+      env: JHUB_VER=0.8.1
     allow_failures:
       - env: JHUB_VER=master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - git clone --quiet --branch $JHUB_VER https://github.com/jupyter/jupyterhub.git jupyterhub
 install:
+# Don't let requirements pull in tornado 5 yet
+    - pip install "tornado<5.0"
     - pip install --pre -f travis-wheels/wheelhouse -r jupyterhub/dev-requirements.txt .
     - pip install --pre -e jupyterhub
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - JHUB_VER=0.5.0
     - JHUB_VER=0.6.1
     - JHUB_VER=0.7.2
-    - JHUB_VER=0.8.0
+    - JHUB_VER=0.8.1
 matrix:
     include:
     - python: 3.6
@@ -26,8 +26,8 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - git clone --quiet --branch $JHUB_VER https://github.com/jupyter/jupyterhub.git jupyterhub
 install:
-# Don't let requirements pull in tornado 5 yet
-    - pip install "tornado<5.0"
+# Don't let requirements pull in tornado 5 yet except for jupyterhub master
+    - if [ $JHUB_VER != "master" ]; then pip install "tornado<5.0"; fi
     - pip install --pre -f travis-wheels/wheelhouse -r jupyterhub/dev-requirements.txt .
     - pip install --pre -e jupyterhub
 script:


### PR DESCRIPTION
To get the tests working, we need to conditionally pin the tornado version. Specifically we conditionally install tornado before the jupyterhub dev-requirements.txt file is processed. The reason is that by default we will pull in tornado 5.0, which breaks the testing because

- it cannot be installed on Python 3.3
- the jupyterhub test suite is broken on tornado 5.0 for the released versions (currently through 0.8.1)

This branch lets Jupyterhub pull in the default tornado version for the master branch (allowed to fail) but otherwise uses 4.1<ver<5.0. We also bump the newest tested jupyterhub release to 0.8.1.