### PR TITLE
slurm: remove --uid option (redundant with sudo)

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -476,7 +476,6 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
 #SBATCH --workdir={homedir}
 #SBATCH --mem={memory}
 #SBATCH --export={keepvars}
-#SBATCH --uid={username}
 #SBATCH --get-user-env=L
 #SBATCH {options}
 


### PR DESCRIPTION
This change was needed for our cluster which was just upgraded to slurm 17.11.5: without it, we get `Error: sbatch: error: --uid only permitted by root user`.  Since we use sudo to run sbatch, it seems that an explicit `--uid` option is not needed.  This would be needed if we supported submitting as an admin user and slurm handles the user changing - but it seems sudo is probably the better option.  Thoughts?

Commit comment:

- The --uid option is not allowed for non-root users anymore in Slurm17.11.5 (at least)...
- Since we submit using sudo, this option seems to be no longer needed.