### PR TITLE
Basic implementation of jinja2 templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Common attributes of batch submission / resource manager environments will inclu
   * job names instead of PIDs
 
 `BatchSpawnerBase` provides several general mechanisms:
-  * configurable traits `req_foo` that are exposed as `{foo}` in job template scripts
+  * configurable traits `req_foo` that are exposed as `{foo}` in job template scripts.  Templates (submit scripts in particular) may also use the full power of [jinja2](http://jinja.pocoo.org/).  Templates are automatically detected if a `{{` or `{%` is present, otherwise str.format() used.
   * configurable command templates for submitting/querying/cancelling jobs
   * a generic concept of job-ID and ID-based job state tracking
   * overrideable hooks for subclasses to plug in logic at numerous points

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+jinja2
 jupyterhub>=0.5


### PR DESCRIPTION
Initial attempt at jinja2 templates.  Backwards compatible and works for me, but needs documentation and a bit more before finalizing.  Is this wanted?

- If the batch_script or any other string has {{ or {% in it, treat it
  as a jinja2 template and do advanced formatting.
- Allows for optional options to be more easily supported.
- Initial implementation for SlurmSpawner only.

Also solves #64.