### PR TITLE
Add exec_prefix option

### DIFF
--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -17,6 +17,7 @@ testhost = "userhost123"
 testjob  = "12345"
 
 class BatchDummy(BatchSpawnerRegexStates):
+    exec_prefix = ''
     batch_submit_cmd = Unicode('cat > /dev/null; echo '+testjob)
     batch_query_cmd = Unicode('echo RUN '+testhost)
     batch_cancel_cmd = Unicode('echo STOP')


### PR DESCRIPTION
- This adds the option exec_prefix which can be used for overriding
  the sudo command to use when manipulating jobs.
- This defaults to "sudo -E -u {username}" and is appended to every
  command before it is run.
- The condor_q command did not have sudo, but likely can be used here.
- Closes: #39 

Missing and very important: tests to ensure that exec_prefix is actually used.  But please pull #72 first since that will make things easier to test.