### PR TITLE
Updates to slurm script: proper termination and generalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Common attributes of batch submission / resource manager environments will inclu
   * job names instead of PIDs
 
 `BatchSpawnerBase` provides several general mechanisms:
-  * configurable traits `req_foo` that are exposed as `{foo}` in job template scripts
+  * configurable traits `req_foo` that are exposed as `{foo}` in job template scripts.  Templates (submit scripts in particular) may also use the full power of [jinja2](http://jinja.pocoo.org/).  Templates are automatically detected if a `{{` or `{%` is present, otherwise str.format() used.
   * configurable command templates for submitting/querying/cancelling jobs
   * a generic concept of job-ID and ID-based job state tracking
   * overrideable hooks for subclasses to plug in logic at numerous points

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -143,6 +143,14 @@ class BatchSpawnerBase(Spawner):
         help="Other options to include into job submission script"
         ).tag(config=True)
 
+    req_prologue = Unicode('', \
+        help="Scipt to run before single user server starts."
+        ).tag(config=True)
+
+    req_epilogue = Unicode('', \
+        help="Scipt to run after single user server end."
+        ).tag(config=True)
+
     req_username = Unicode()
     @default('req_username')
     def _req_username_default(self):
@@ -500,8 +508,12 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
 {% endif %}{% if nprocs     %}#SBATCH --cpus-per-task={{nprocs}}
 {% endif %}{% if options    %}#SBATCH {{options}}{% endif %}
 
+trap 'echo SIGTERM received' TERM
+{{prologue}}
 which jupyterhub-singleuser
-{{cmd}}
+srun {{cmd}}
+echo "jupyterhub-singleuser ended gracefully"
+{{epilogue}}
 """).tag(config=True)
     # outputs line like "Submitted batch job 209"
     batch_submit_cmd = Unicode('sudo -E -u {username} sbatch --parsable').tag(config=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+jinja2
 jupyterhub>=0.5


### PR DESCRIPTION
This PR is necessarily based on #66 (jinja2 templating).  That one should be pulled first, then this diff will make sense.

- By using `srun` for cmd, slurm will properly signal shutdown with
  SIGTERM in advance.  Closes: #50
- Add prologue and epilogue options in case other setup is needed
  before or after the script runs (e.g. `unset XDG_RUNTIME_DIR`).
- Some other script nicesess.
- This will eventually need porting to the other spawners, but will
  require some local knowledge.  Slurm first, then others.
