### PR TITLE
Test with jupyterhub 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - JHUB_VER=0.6.1
     - JHUB_VER=0.7.2
     - JHUB_VER=0.8.1
+    - JHUB_VER=0.9.0b2
 matrix:
     include:
     - python: 3.6
@@ -18,6 +19,10 @@ matrix:
     exclude:
     - python: 3.3
       env: JHUB_VER=0.8.1
+    - python: 3.3
+      env: JHUB_VER=0.9.0b2
+    - python: 3.4
+      env: JHUB_VER=0.9.0b2
     allow_failures:
       - env: JHUB_VER=master
 
@@ -27,7 +32,7 @@ before_install:
     - git clone --quiet --branch $JHUB_VER https://github.com/jupyter/jupyterhub.git jupyterhub
 install:
 # Don't let requirements pull in tornado 5 yet except for jupyterhub master
-    - if [ $JHUB_VER != "master" ]; then pip install "tornado<5.0"; fi
+    - if [ $JHUB_VER != "master" -a $JHUB_VER != "0.9.0b2" ]; then pip install "tornado<5.0"; fi
     - pip install --pre -f travis-wheels/wheelhouse -r jupyterhub/dev-requirements.txt
     - pip install --pre -e jupyterhub
 


### PR DESCRIPTION
Add jupyterhub 0.9.0b2 to travis.yml, but will need updating as jupyterhub beta releases progress.

Closes: #78.  See also discussion there about simplifying the matrix.

