### PR TITLE
[WIP] Add progress indicators for jupyterhub 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
     - pip install attrs>17.4.0
     - pip install --pre -r jupyterhub/dev-requirements.txt
     - pip install --pre -e jupyterhub
+    - pip install --pre -f travis-wheels/wheelhouse -r requirements.txt
 
 script:
     - travis_retry py.test --lf --cov batchspawner batchspawner/tests -v

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -430,7 +430,7 @@ class BatchSpawnerBase(Spawner):
                 await yield_({
                     "message": "Unknown status...",
                 })
-            await gen.sleep(.1)
+            await gen.sleep(1)
 
 class BatchSpawnerRegexStates(BatchSpawnerBase):
     """Subclass of BatchSpawnerBase that uses config-supplied regular expressions

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -15,9 +15,12 @@ Common attributes of batch submission / resource manager environments will inclu
   * remote execution via submission of templated scripts
   * job names instead of PIDs
 """
+import asyncio
+from async_generator import async_generator, yield_, yield_from_
 import pwd
 import os
 import re
+import sys
 
 import xml.etree.ElementTree as ET
 
@@ -411,6 +414,23 @@ class BatchSpawnerBase(Spawner):
                              self.job_id, self.current_ip, self.port)
                 )
 
+    @async_generator
+    async def progress(self):
+        while True:
+            if self.state_ispending():
+                await yield_({
+                    "message": "Pending in queue...",
+                })
+            elif self.state_isrunning():
+                await yield_({
+                    "message": "Cluster job running... waiting to connect",
+                })
+                return
+            else:
+                await yield_({
+                    "message": "Unknown status...",
+                })
+            await gen.sleep(.1)
 
 class BatchSpawnerRegexStates(BatchSpawnerBase):
     """Subclass of BatchSpawnerBase that uses config-supplied regular expressions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+async_generator>=1.8
 jinja2
 jupyterhub>=0.5


### PR DESCRIPTION
This was my attempt at adding progress indicators for JupyterHub 0.9 ( jupyterhub/jupyterhub#1771), #81 of batchspawner.  However, it just doesn't work.  In fact, I find no indication it is even using this .progress method at all, which makes me think there is something fundamentally wrong with what I am doing (if I put an exception in it, it doesn't raise it... it always uses the base Spawner .progress method.).

There is some junk in here still: it's artificially slowing down to make it last longer.  I've also tried to using async_generator instead of gen.coroutine.  It also doesn't do anything useful, since I was just trying to get *any* sign of it working first, but it can integrate with the spawner estimated start times and so on before this is ready to go.

Any ideas? Any known implementations in other spawners yet yet?

@minrk ?