### PR TITLE
.travis.yml: Require JupyterHub>0.8.1 and Python>3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,22 @@ python:
     - 3.6
     - 3.5
     - 3.4
-    - 3.3
 env:
-    - JHUB_VER=0.5.0
-    - JHUB_VER=0.6.1
     - JHUB_VER=0.7.2
     - JHUB_VER=0.8.1
     - JHUB_VER=0.9.0b2
 matrix:
     include:
-    - python: 3.6
-      env: JHUB_VER=master
+     - python: 3.7-dev
+       env: JHUB_VER=0.9.0b2
+     - python: 3.6
+       env: JHUB_VER=master
     exclude:
-    - python: 3.3
-      env: JHUB_VER=0.8.1
-    - python: 3.3
-      env: JHUB_VER=0.9.0b2
-    - python: 3.4
-      env: JHUB_VER=0.9.0b2
+     - python: 3.4
+       env: JHUB_VER=0.9.0b2
     allow_failures:
       - env: JHUB_VER=master
+      - python: 3.7-dev
 
 before_install:
     - npm install -g configurable-http-proxy


### PR DESCRIPTION
- Mirrors the latest requirements of JupyterHub.
- Discussion in #78.

I'm not necessarily saying that this is a good idea. From #78:

I tend to think that HPC is rather conservative and slow to upgrade, so my inclination is to support backwards compatibility a lot. But, JupyterHub is changing so fast it probably doesn't make sense to use anything older than 0.8.1 anyway.

If it was up to me, I would say "yes" for the main reason that I'm not going to be able to support older versions very well since I have only recently started here.  If we don't do this, can someone help with older versions?

Thoughts?