### PR TITLE
Add reservation option for Slurm

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -513,7 +513,7 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
         help="QoS name to submit job to resource manager"
         ).tag(config=True)
 
-   req_reservation = Unicode('', \
+    req_reservation = Unicode('', \
         help="Reservation name to submit to resource manager"
         ).tag(config=True)
 

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -513,6 +513,10 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
         help="QoS name to submit job to resource manager"
         ).tag(config=True)
 
+   req_reservation = Unicode('', \
+        help="Reservation name to submit to resource manager"
+        ).tag(config=True)
+
     batch_script = Unicode("""#!/bin/bash
 #SBATCH --output={{homedir}}/jupyterhub_slurmspawner_%j.log
 #SBATCH --job-name=spawner-jupyterhub


### PR DESCRIPTION
Hi there,
I know for certain that Slurm can take a full text reservation name - perhaps the other schedulers can use this. But having this optional flag is nice for busier clusters.