### PR TITLE
SlurmSpawner: make "srun" optional

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -513,6 +513,11 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
         help="QoS name to submit job to resource manager"
         ).tag(config=True)
 
+    req_srun = Unicode('srun',
+        help="Job step wrapper, default 'srun'.  Set to '' you do not want "
+             "to run in job step (affects environment handling)"
+        ).tag(config=True)
+
     batch_script = Unicode("""#!/bin/bash
 #SBATCH --output={{homedir}}/jupyterhub_slurmspawner_%j.log
 #SBATCH --job-name=spawner-jupyterhub
@@ -528,7 +533,7 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
 trap 'echo SIGTERM received' TERM
 {{prologue}}
 which jupyterhub-singleuser
-srun {{cmd}}
+{% if srun %}{{srun}} {% endif %}{{cmd}}
 echo "jupyterhub-singleuser ended gracefully"
 {{epilogue}}
 """).tag(config=True)


### PR DESCRIPTION
- To properly run in slurm, one is supposed to use "srun" for each job
  step (though this isn't required).  dff4482 added the srun, but this
  has some side-effects, mainly (for me at least) that environment is
  *actually* handled the way it should be.  But this broke some
  functionality that depended on environment.  Since this caused
  problems, and may cause problems for others, "srun" should be made
  optional.  This does that.
- The root problem is that the batch script reads .bashrc /
  .bash_profile, but when the notebook server is run using 'srun', it
  clears these environment variables and uses only the keepvars
  setting.  (Of course, this itself is a security risk and the initial
  purpose of limiting the environment).
- To disable srun, set SlurmSpawner.req_srun=''.
- If, upon upgrading, your environment goes crazy and you aren't
  seeing environment variables you expected, try setting this to ''.