### PR TITLE
[WIP] Add SPAWNERS.md, a list of specific info on spawners

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This package formerly included WrapSpawner and ProfilesSpawner, which provide me
 
 ## Batch Spawners
 
+For information on the specific spawners, see [SPAWNERS.md](SPAWNERS.md).
+
 ### Overview
 
 This file contains an abstraction layer for batch job queueing systems (`BatchSpawnerBase`), and implements
@@ -81,6 +83,15 @@ to run Jupyter notebooks on an academic supercomputer cluster.
    # For our site we need to munge the execution hostname returned by qstat
    c.TorqueSpawner.state_exechost_exp = r'int-\1.mesabi.xyz.edu'
    ```
+
+### Security
+
+Unless otherwise stated for a specific spawner, assume that spawners
+*do* evaluate shell environment for users and thus the [security
+requriemnts of JupyterHub security for untrusted
+users](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html)
+are not fulfilled.
+
 
 ## Provide different configurations of BatchSpawner
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Unless otherwise stated for a specific spawner, assume that spawners
 *do* evaluate shell environment for users and thus the [security
 requriemnts of JupyterHub security for untrusted
 users](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html)
-are not fulfilled.
+are not fulfilled.  This is something which we are working on.
 
 
 ## Provide different configurations of BatchSpawner

--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ Unless otherwise stated for a specific spawner, assume that spawners
 *do* evaluate shell environment for users and thus the [security
 requriemnts of JupyterHub security for untrusted
 users](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html)
-are not fulfilled.  This is something which we are working on.
+are not fulfilled because some (most?) spawners *do* start a user
+shell which will execute arbitrary user environment configuration
+(``.profile``, ``.bashrc`` and the like) unless users do not have
+access to their own cluster user account.  This is something which we
+are working on.
 
 
 ## Provide different configurations of BatchSpawner

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ to run Jupyter notebooks on an academic supercomputer cluster.
 
 Unless otherwise stated for a specific spawner, assume that spawners
 *do* evaluate shell environment for users and thus the [security
-requriemnts of JupyterHub security for untrusted
+requiremnts of JupyterHub security for untrusted
 users](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html)
 are not fulfilled because some (most?) spawners *do* start a user
 shell which will execute arbitrary user environment configuration

--- a/SPAWNERS.md
+++ b/SPAWNERS.md
@@ -42,8 +42,13 @@ Maintainers:
 
 # Checklist for making spawners
 
+Please document each of these things under the spawner list above, -
+even if it is "OK", we need to track status of all spawners.  If it is
+a bug, users really need to know.
+
 - Does your spawner read shell environment before starting?  (See
-  [Jupyterhub Security](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html).
+  [Jupyterhub
+  Security](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html).
 
 - Does your spawner send SIGTERM to the jupyterhub-singleuser process
   before SIGKILL?  It should, so that the process can terminate

--- a/SPAWNERS.md
+++ b/SPAWNERS.md
@@ -16,9 +16,13 @@ Maintainers:
 
 Maintainers: @rkdarst
 
-This spawner enforces the environment if `srun` is used, which is the
-default.  If you *do* want user environment to be used, set
-`req_srun=''`.
+This spawner enforces the environment if `srun` is used to wrap the
+spawner command, which is the default.  If you *do* want user
+environment to be used, set `req_srun=''`.  However, this is not
+perfect: there is still a bash shell begun as the user which could run
+arbitrary startup, define shell aliases for `srun`, etc.
+
+Use of `srun` is required to gracefully terminate.
 
 
 ## `GridengineSpawner`
@@ -38,12 +42,14 @@ Maintainers:
 
 # Checklist for making spawners
 
-- Does your spawner read shell environment before starting?
+- Does your spawner read shell environment before starting?  (See
+  [Jupyterhub Security](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html).
 
 - Does your spawner send SIGTERM to the jupyterhub-singleuser process
   before SIGKILL?  It should, so that the process can terminate
-  gracefully.  If you don't see the script end (e.g. you can add `echo
-  "terminated gracefully"` to the end of your script and see it), you
-  should check.  PR #75 might help here, ask the poster to finalize
-  it.
+  gracefully.  Add `echo "terminated gracefully"` to the end of the
+  batch script - if you see this in your singleuser server output, you
+  know that you DO receive SIGTERM and terminate gracefully.  If your
+  batch system can not automatically send SIGTERM before SIGKILL, PR
+  #75 might help here, ask for it to be finished.
 

--- a/SPAWNERS.md
+++ b/SPAWNERS.md
@@ -1,0 +1,49 @@
+# Notes on specific spawners
+
+## `TorqueSpawner`
+
+Maintainers:
+
+
+## `MoabSpawner`
+
+Subclass of TorqueSpawner
+
+Maintainers:
+
+
+## `SlurmSpawner`
+
+Maintainers: @rkdarst
+
+This spawner enforces the environment if `srun` is used, which is the
+default.  If you *do* want user environment to be used, set
+`req_srun=''`.
+
+
+## `GridengineSpawner`
+
+Maintainers:
+
+
+## `CondorSpawner`
+
+Maintainers:
+
+
+## `LsfSpawner`
+
+Maintainers:
+
+
+# Checklist for making spawners
+
+- Does your spawner read shell environment before starting?
+
+- Does your spawner send SIGTERM to the jupyterhub-singleuser process
+  before SIGKILL?  It should, so that the process can terminate
+  gracefully.  If you don't see the script end (e.g. you can add `echo
+  "terminated gracefully"` to the end of your script and see it), you
+  should check.  PR #75 might help here, ask the poster to finalize
+  it.
+


### PR DESCRIPTION
This creates a separate page to list specific spawner information, and eventually design considerations (security, graceful termination) for spawners.  It can be used so that each specific spawner maintainer can ensure that their spawner meets all important requirements.

Another idea here is "spawner maintainers", since not everyone can know about all of them.  The idea is that we can keep track of who knows about which, and ping them when necessary.

Any comments on these notes, anything to add?