### PR TITLE
run_command: Fix possible deadlock

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -189,8 +189,8 @@ class BatchSpawnerBase(Spawner):
                 # Apparently harmless
                 pass
         proc.stdin.close()
-        out = yield proc.stdout.read_until_close()
-        eout = yield proc.stderr.read_until_close()
+        out, eout = yield [proc.stdout.read_until_close(),
+                           proc.stderr.read_until_close()]
         proc.stdout.close()
         proc.stderr.close()
         eout = eout.decode().strip()


### PR DESCRIPTION
- Reading from stdout and stderr separately can produce a deadlock.  I
  assume that the separate proc.wait_for_exit() doesn't matter here.
- Thanks to @krinsman in #90.