### PR TITLE
pin attrs for jsonschema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,12 @@ matrix:
 
 before_install:
     - npm install -g configurable-http-proxy
-    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - git clone --quiet --branch $JHUB_VER https://github.com/jupyter/jupyterhub.git jupyterhub
 install:
 # Don't let requirements pull in tornado 5 yet except for jupyterhub master
     - if [ $JHUB_VER != "master" -a $JHUB_VER != "0.9.1" ]; then pip install "tornado<5.0"; fi
-    - pip install jsonschema!=3.0.0a1   # issue #110, remove later
-    - pip install --pre -f travis-wheels/wheelhouse -r jupyterhub/dev-requirements.txt
+    - pip install attrs>=17.4.0   # pip isn't resolving jsonschema's requirements correctly
+    - pip install --pre -r jupyterhub/dev-requirements.txt
     - pip install --pre -e jupyterhub
 
 script:


### PR DESCRIPTION
jsonschema 3.0 requires attrs 17.4, but pip doesn’t seem to pull it in

closes #110