### PR TITLE
Environment handling refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ shell which will execute arbitrary user environment configuration
 access to their own cluster user account.  This is something which we
 are working on.
 
+The `admin_environment` option claims to pass environment only to the
+batch spawners, and not the user servers.  This relies on each spawner
+handling environment correctly, and this is *not* checked so you
+should *not* rely on this yet.
 
 ## Provide different configurations of BatchSpawner
 
@@ -162,6 +166,7 @@ Added (user)
 * Add new option exec_prefix, which defaults to `sudo -E -u {username}`.  This replaces explicit `sudo` in every batch command - changes in local commands may be needed.
 * Add `req_prologue` and `req_epilogue` options to scripts which are inserted before/after the main jupyterhub-singleuser command, which allow for generic setup/cleanup without overriding the entire script.  #96
 * SlurmSpawner: add the `req_reservation` option.  #
+* Add the option `admin_environment` which get passed to the batch submission commands (like for authentication) but *not* to the `--export=keepvars` options.  This *should* mean that it is not passed to the user, but not every spawner is checked, so this should *not* be relied on.
 
 Added (developer)
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Added (user)
 
 * Add Jinja2 templating as an option for all scripts and commands.  If '{{' or `{%` is used anywhere in the string, it is used as a jinja2 template.
 * Add new option exec_prefix, which defaults to `sudo -E -u {username}`.  This replaces explicit `sudo` in every batch command - changes in local commands may be needed.
-* New option: `req_keepvars_extra`, which allows keeping extra variables in addition to what is defined by JupyterHub itself (addition of variables to keep instead of replacement).  #99
 * Add `req_prologue` and `req_epilogue` options to scripts which are inserted before/after the main jupyterhub-singleuser command, which allow for generic setup/cleanup without overriding the entire script.  #96
 * SlurmSpawner: add the `req_reservation` option.  #
 
@@ -172,6 +171,7 @@ Added (developer)
 Changed
 
 * Update minimum requirements to JupyterHub 0.8.1 and Python 3.4.
+* Change meaning of `req_keepvars`.  Previously, setting this would override everything that JupyterHub requires to be set (so you'd have to make sure you set it back).  Now, `req_keepvars` only *adds* to the JupyterHub defaults, and `req_keepvars_default` gets set to the JupyterHub upstream and can be used to completly override the JupyterHub defaults. #99, #??
 * Update Slurm batch script.  Now, the single-user notebook is run in a job step, with a wrapper of `srun`.  This may need to be removed using `req_srun=''` if you don't want environment variables limited.
 * Pass the environment dictionary to the queue and cancel commands as well.  This is mostly user environment, but may be useful to these commands as well in some cases. #108, #111  If these envioronment variables were used for authentication as an admin, be aware that there are pre-existing security issues because they may be passed to the user via the batch submit command, see #82.
 

--- a/SPAWNERS.md
+++ b/SPAWNERS.md
@@ -22,6 +22,8 @@ environment to be used, set `req_srun=''`.  However, this is not
 perfect: there is still a bash shell begun as the user which could run
 arbitrary startup, define shell aliases for `srun`, etc.
 
+`admin_environment` does work with SlurmSpawner.
+
 Use of `srun` is required to gracefully terminate.
 
 

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -205,6 +205,23 @@ class BatchSpawnerBase(Spawner):
     def cmd_formatted_for_batch(self):
         return ' '.join(self.cmd + self.get_args())
 
+    def get_admin_env(self):
+        """Get the environment passed to the batch submit/cancel/etc commands.
+
+        This contains all of the output from self.get_env(), plus any
+        variables defined in self.admin_environment.  In fact, only this
+        command is used to pass to batch commands, and the only use of
+        self.get_env() is producing the list of variables to be
+        --export='ed to.  Everything in get_env *must* also be in here
+        or else it won't be used.
+        """
+        env = self.get_env()
+        if self.admin_environment:
+            for key in self.admin_environment.split(','):
+                if key in os.environ and key not in env:
+                    env[key] = os.environ[key]
+        return env
+
     @gen.coroutine
     def run_command(self, cmd, input=None, env=None):
         proc = Subprocess(cmd, shell=True, env=env, stdin=Subprocess.STREAM, stdout=Subprocess.STREAM,stderr=Subprocess.STREAM)

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -139,15 +139,30 @@ class BatchSpawnerBase(Spawner):
     def _req_homedir_default(self):
         return pwd.getpwnam(self.user.name).pw_dir
 
-    req_keepvars = Unicode()
-    @default('req_keepvars')
-    def _req_keepvars_default(self):
+    req_keepvars_default = Unicode(
+        help="All environment variables to pass to the spawner.  This is set "
+             "to a default by JupyterHub, and if you change this list "
+             "the previous ones are _not_ included and your submissions will "
+             "break unless you re-add necessary variables.  Consider "
+             "req_keepvars for most use cases."
+)
+    @default('req_keepvars_all')
+    def _req_keepvars_all_default(self):
         return ','.join(self.get_env().keys())
 
-    req_keepvars_extra = Unicode(
+    req_keepvars = Unicode(
         help="Extra environment variables which should be configured, "
               "added to the defaults in keepvars, "
-              "comma separated list.")
+              "comma separated list.").tag(config=True)
+    admin_environment = Unicode(
+        help="Comma-separated list of environment variables to be passed to "
+             "the batch submit/cancel commands, but _not_ to the batch script "
+             "via --export.  This could be used, for example, to authenticate "
+             "the submit command as an admin user so that it can submit jobs "
+             "as another user.  These are _not_ included in an "
+             "--export={keepvars} type line in the batch script, but you "
+             "should check that your batch system actually does the right "
+             "thing here.").tag(config=True)
 
     batch_script = Unicode('',
         help="Template for job submission script. Traits on this class named like req_xyz "
@@ -170,8 +185,13 @@ class BatchSpawnerBase(Spawner):
         subvars = {}
         for t in reqlist:
             subvars[t[4:]] = getattr(self, t)
-        if subvars.get('keepvars_extra'):
-            subvars['keepvars'] += ',' + subvars['keepvars_extra']
+        # 'keepvars' is special: 'keepvars' goes through as the
+        # variable, but 'keepvars_default' is prepended to it.
+        # 'keepvars_default' is JH-required stuff so you have to try
+        # extra hard to override it.
+        if subvars.get('keepvars'):
+            subvars['keepvars_default'] += ',' + subvars['keepvars']
+        subvars['keepvars'] = subvars['keepvars_default']
         return subvars
 
     batch_submit_cmd = Unicode('',

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -455,7 +455,7 @@ def test_lfs(db, io_loop):
 def test_keepvars(db, io_loop):
     # req_keepvars
     spawner_kwargs = {
-        'req_keepvars': 'ABCDE',
+        'req_keepvars_default': 'ABCDE',
         }
     batch_script_re_list = [
         re.compile(r'--export=ABCDE', re.X|re.M),
@@ -464,10 +464,32 @@ def test_keepvars(db, io_loop):
                               spawner_kwargs=spawner_kwargs,
                               batch_script_re_list=batch_script_re_list)
 
-    # req_keepvars AND req_keepvars together
+    # req_keepvars
     spawner_kwargs = {
         'req_keepvars': 'ABCDE',
-        'req_keepvars_extra': 'XYZ',
+        }
+    batch_script_re_list = [
+        re.compile(r'--export=.*ABCDE', re.X|re.M),
+        ]
+    run_typical_slurm_spawner(db, io_loop,
+                              spawner_kwargs=spawner_kwargs,
+                              batch_script_re_list=batch_script_re_list)
+
+    # req_keepvars
+    spawner_kwargs = {
+        'admin_environment': 'ABCDE',
+        }
+    batch_script_re_list = [
+        re.compile(r'^((?!ABCDE).)*$', re.X|re.S),
+        ]
+    run_typical_slurm_spawner(db, io_loop,
+                              spawner_kwargs=spawner_kwargs,
+                              batch_script_re_list=batch_script_re_list)
+
+    # req_keepvars AND req_keepvars together
+    spawner_kwargs = {
+        'req_keepvars_default': 'ABCDE',
+        'req_keepvars': 'XYZ',
         }
     batch_script_re_list = [
         re.compile(r'--export=ABCDE,XYZ', re.X|re.M),


### PR DESCRIPTION
`req_keepvars` implies that it is for setting environment variables - but to use it, you have to re-add all of the JH defaults.  This is not very intuitive, and makes it not very useful.

Rename `req_keepvars` to `req_keepvars_default` - this is pre-filled by default with the output from `jupyterhub.spawner.Spawner.get_env()` which is the environment that JH thinks that singleuser servers need.

Add a new `req_keepvars` which gets added to `req_keepvars_default` to become the actual `req_keepvars` in the batch script.  This and previous would probably have helped with #118, 

Add a new `admin_environment` which is added to the environment for running the commands, but not the `--export={keepvars}` in the scripts.  This can be used to authenticate to batch systems in something as an admin.  Note that it is not yet guaranteed that this works in all spawners.

Any thoughts on these?

All together these help with #82, considering security.