### PR TITLE
Wrapspawner/JH0.9.4 compatibilty: get_current_user and current_port

### DIFF
--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -14,7 +14,11 @@ class BatchSpawnerAPIHandler(APIHandler):
             user = self.get_current_user()
         data = self.get_json_body()
         port = int(data.get('port', 0))
-        user.spawner.current_port = port
+        if hasattr(user.spawner, 'child_spawner'):
+            # When using wrapspawner, #127 and #129
+            user.spawner.child_spawner.current_port = port
+        else:
+            user.spawner.current_port = port
         self.finish(json.dumps({"message": "BatchSpawner port configured"}))
         self.set_status(201)
 

--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -6,7 +6,12 @@ class BatchSpawnerAPIHandler(APIHandler):
     @web.authenticated
     def post(self):
         """POST set user's spawner port number"""
-        user = self.get_current_user()
+        if hasattr(self, 'current_user'):
+            # Jupyterhub compatability, (september 2018, d79a99323ef1d)
+            user = self.current_user
+        else:
+            # Previous jupyterhub, 0.9.4 and before.
+            user = self.get_current_user()
         data = self.get_json_body()
         port = int(data.get('port', 0))
         user.spawner.current_port = port


### PR DESCRIPTION
This fixes two problems:

First is a compatibility for JupyterHub later than 0.9.4 (but not inclusive).  get_current_user became async, and thus we need to handle both old and new hubs.  This adds some logic to use the non-async version to avoid making this whole method async - because `jupyterhub.util.maybe_future` is also relatively new so would need backwards compatibility to use itself.  Closes: #131

Second, wrapspawner has to proxy the `self.current_port` setting to `self.child_spawner.current_port`.  It would be better to solve this in wrapspawner, since many different things could be set.  But this might solve the problem faster.  Closes: #129, #127, 

These are together because they touch lines almost identical to each other.  They can easily be split.
