### PR TITLE
Add support for JupyterLab instances

### DIFF
--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,7 +1,6 @@
 from jupyterhub.singleuser import SingleUserNotebookApp
 from jupyterhub.utils import random_port, url_path_join
 from traitlets import default
-import sys
 
 class BatchSingleUserNotebookApp(SingleUserNotebookApp):
     @default('port')
@@ -23,7 +22,7 @@ except ImportError:
 else:
     class BatchSingleUserLabApp(BatchSingleUserNotebookApp, LabApp):
 
-        @default
+        @default("default_url")
         def _default_url(self):
             """when using jupyter-labhub, jupyterlab is default ui"""
             return "/lab"
@@ -47,11 +46,14 @@ else:
             settings['page_config_data']['token'] = api_token
 
 def main(argv=None):
-    if len(argv) > 1 and argv[1] == "lab" and BatchSingleUserLabApp != None:
-        del argv[1]
+    if isinstance(argv, list) and argv[0] == "lab" and BatchSingleUserLabApp != None:
+        if len(argv) > 1:
+            del argv[0]
+        else:
+            argv=None
         return BatchSingleUserLabApp.launch_instance(argv)
     else:
         return BatchSingleUserNotebookApp.launch_instance(argv)
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main()

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -20,6 +20,7 @@ except ImportError:
     BatchSingleUserLabApp = None
     pass
 else:
+    import os
     class BatchSingleUserLabApp(BatchSingleUserNotebookApp, LabApp):
 
         @default("default_url")

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,6 +1,7 @@
 from jupyterhub.singleuser import SingleUserNotebookApp
 from jupyterhub.utils import random_port, url_path_join
 from traitlets import default
+import sys
 
 class BatchSingleUserNotebookApp(SingleUserNotebookApp):
     @default('port')
@@ -14,8 +15,43 @@ class BatchSingleUserNotebookApp(SingleUserNotebookApp):
                                    json={'port' : self.port})
         super().start()
 
+try:
+    from jupyterlab.labapp import LabApp
+except ImportError:
+    BatchSingleUserLabApp = None
+    pass
+else:
+    class BatchSingleUserLabApp(BatchSingleUserNotebookApp, LabApp):
+
+        @default
+        def _default_url(self):
+            """when using jupyter-labhub, jupyterlab is default ui"""
+            return "/lab"
+
+        def init_webapp(self, *args, **kwargs):
+            super().init_webapp(*args, **kwargs)
+            settings = self.web_app.settings
+            if 'page_config_data' not in settings:
+                settings['page_config_data'] = {}
+            settings['page_config_data']['hub_prefix'] = self.hub_prefix
+            settings['page_config_data']['hub_host'] = self.hub_host
+            settings['page_config_data']['hub_user'] = self.user
+            api_token = os.getenv('JUPYTERHUB_API_TOKEN')
+            if not api_token:
+                api_token = ''
+            if not self.token:
+                try:
+                    self.token = api_token
+                except AttributeError:
+                    self.log.error("Can't set self.token")
+            settings['page_config_data']['token'] = api_token
+
 def main(argv=None):
-    return BatchSingleUserNotebookApp.launch_instance(argv)
+    if len(argv) > 1 and argv[1] == "lab" and BatchSingleUserLabApp != None:
+        del argv[1]
+        return BatchSingleUserLabApp.launch_instance(argv)
+    else:
+        return BatchSingleUserNotebookApp.launch_instance(argv)
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv)

--- a/scripts/batchspawner-singleuser
+++ b/scripts/batchspawner-singleuser
@@ -3,4 +3,8 @@
 from batchspawner.singleuser import main
 
 if __name__ == '__main__':
-    main()
+    if len(argv) > 1:
+        from sys import argv
+        main(argv[1:])
+    else:
+        main()

--- a/scripts/batchspawner-singleuser
+++ b/scripts/batchspawner-singleuser
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 from batchspawner.singleuser import main
+from sys import argv
 
 if __name__ == '__main__':
     if len(argv) > 1:
-        from sys import argv
         main(argv[1:])
     else:
         main()


### PR DESCRIPTION
Since JupyterHub is capable of handling both JupyterLab instances as well as Notebook instances, I have added support here for launching JupyterLab instances in batchspawner-singleuser.  It should not affect current configurations that are just launching  notebooks by default.  There is probably a better way of handling the app selection, but for now I have it so that one can choose the lab instance by passing 'lab' on the command line to `batchspawner-singleuser`.  Doing it this way instead of with a configurable should make it so that those using wrap/profile spawners can have profiles for JupyterLab and Jupyter notebook that can be chosen on the fly.