### PR TITLE
Grab environment variables needed for grid engine

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -683,6 +683,16 @@ class GridengineSpawner(BatchSpawnerBase):
         self.log.error("Spawner unable to match host addr in job {0} with status {1}".format(self.job_id, self.job_status))
         return
 
+    def get_env(self):
+        env = super().get_env()
+
+        # SGE relies on environment variables to launch local jobs.  Ensure that these values are included
+        # in the environment used to run the spawner.
+        for key in ['SGE_CELL','SGE_EXECD','SGE_ROOT','SGE_CLUSTER_NAME','SGE_QMASTER_PORT', 'SGE_EXECD_PORT','PATH']:
+            if key in os.environ and key not in env:
+                env[key] = os.environ[key]
+        return env
+
 
 class CondorSpawner(UserEnvMixin,BatchSpawnerRegexStates):
     batch_script = Unicode("""


### PR DESCRIPTION
When running as a service, the path for qsub/qstat/qdel commands is needed in the environment. In addition, several SGE environment variables are needed in order to submit jobs to the cluster. These are mentioned in the SGE install guides and are carried over to Univa Grid Engine as well. 

Here's an older [admin guide (page 7)](http://www.univa.com/resources/files/univa_admin_guide_univa_grid_engine_854.pdf#page=7) describing the variables

Tested with UGE-8.6.4