### PR TITLE
Allow batchspawner to be used with different notebook singleuser cmd

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -74,9 +74,6 @@ class BatchSpawnerBase(Spawner):
         state_gethost
     """
 
-    # override default since will need to set the listening port using the api
-    cmd = Command(['batchspawner-singleuser'], allow_none=True).tag(config=True)
-
     # override default since batch systems typically need longer
     start_timeout = Integer(300).tag(config=True)
 
@@ -190,7 +187,7 @@ class BatchSpawnerBase(Spawner):
         return output
 
     def cmd_formatted_for_batch(self):
-        return ' '.join(self.cmd + self.get_args())
+        return ' '.join(['batchspawner-singleuser'] + self.cmd + self.get_args())
 
     @gen.coroutine
     def run_command(self, cmd, input=None, env=None):

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from runpy import run_path
@@ -9,6 +10,9 @@ from jupyterhub.services.auth import HubAuth
 def main(argv=None):
     port = random_port()
     hub_auth = HubAuth()
+    hub_auth.client_ca = os.environ.get('JUPYTERHUB_SSL_CLIENT_CA', '')
+    hub_auth.certfile = os.environ.get('JUPYTERHUB_SSL_CERTFILE', '')
+    hub_auth.keyfile = os.environ.get('JUPYTERHUB_SSL_KEYFILE', '')
     hub_auth._api_request(method='POST',
                           url=url_path_join(hub_auth.api_url, 'batchspawner'),
                           json={'port' : port})

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,21 +1,21 @@
-from jupyterhub.singleuser import SingleUserNotebookApp
+import sys
+
+from runpy import run_path
+from shutil import which
+
 from jupyterhub.utils import random_port, url_path_join
-from traitlets import default
-
-class BatchSingleUserNotebookApp(SingleUserNotebookApp):
-    @default('port')
-    def _port(self):
-        return random_port()
-
-    def start(self):
-        # Send Notebook app's port number to remote Spawner
-        self.hub_auth._api_request(method='POST',
-                                   url=url_path_join(self.hub_api_url, 'batchspawner'),
-                                   json={'port' : self.port})
-        super().start()
+from jupyterhub.services.auth import HubAuth
 
 def main(argv=None):
-    return BatchSingleUserNotebookApp.launch_instance(argv)
+    port = random_port()
+    hub_auth = HubAuth()
+    hub_auth._api_request(method='POST',
+                          url=url_path_join(hub_auth.api_url, 'batchspawner'),
+                          json={'port' : port})
+
+    cmd_path = which(sys.argv[1])
+    sys.argv = sys.argv[1:] + ['--port={}'.format(port)]
+    run_path(cmd_path, run_name="__main__")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Instead of creating a batchspawner notebook app, batchspawner-singleuser
is now a wrapper that finds a port and add the port number to the
command-line argument of the singleuser app. This allows the usage
of batchspawner with jupyterlab for example.