### PR TITLE
Fix test warnings

### DIFF
--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -61,16 +61,20 @@ def new_spawner(db, spawner_class=BatchDummy, **kwargs):
         hub = Hub()
         user = User(user, {})
         server = Server()
-        kwargs.setdefault('server', server)
+        # Set it after constructions because it isn't a traitlet.
     kwargs.setdefault('hub', hub)
     kwargs.setdefault('user', user)
-    kwargs.setdefault('mock_port', testport)
     kwargs.setdefault('poll_interval', 1)
     if version_info < (0,8):
-        return spawner_class(db=db, **kwargs)
+        spawner = spawner_class(db=db, **kwargs)
+        spawner.mock_port = testport
     else:
         print("JupyterHub >=0.8 detected, using new spawner creation")
-        return user._new_spawner('', spawner_class=spawner_class, **kwargs)
+        # These are not traitlets so we have to set them here
+        spawner = user._new_spawner('', spawner_class=spawner_class, **kwargs)
+        spawner.server = server
+        spawner.mock_port = testport
+    return spawner
 
 def test_stress_submit(db, io_loop):
     for i in range(200):

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -65,9 +65,6 @@ def new_spawner(db, spawner_class=BatchDummy, **kwargs):
     kwargs.setdefault('hub', hub)
     kwargs.setdefault('user', user)
     kwargs.setdefault('mock_port', testport)
-    kwargs.setdefault('INTERRUPT_TIMEOUT', 1)
-    kwargs.setdefault('TERM_TIMEOUT', 1)
-    kwargs.setdefault('KILL_TIMEOUT', 1)
     kwargs.setdefault('poll_interval', 1)
     if version_info < (0,8):
         return spawner_class(db=db, **kwargs)


### PR DESCRIPTION
Tests were giving over 200 warnings - reduce that.

Tests: set 'mock_port' and 'server' explicitely
- Modern traitlets doesn't set arbitrary keyword arguments, and these
 two attributes are not traitlets.  Thus, set them explicitely after
 spawner creation.

- This may fail (server) on the jupyterhub < 0.8 branch, but that is
 deprecated and I will likely remove it shortly.

Dont' set *_TIMEOUT on tests

- These are on LocalProcessSpawner, not Spawner, so do nothing here.
- These were also renamed to lowercase
- In short, these weren't used before