### PR TITLE
Update batchspawner.py to use --chdir instead of --workdir

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -588,7 +588,7 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
     batch_script = Unicode("""#!/bin/bash
 #SBATCH --output={{homedir}}/jupyterhub_slurmspawner_%j.log
 #SBATCH --job-name=spawner-jupyterhub
-#SBATCH --workdir={{homedir}}
+#SBATCH --chdir={{homedir}}
 #SBATCH --export={{keepvars}}
 #SBATCH --get-user-env=L
 {% if partition  %}#SBATCH --partition={{partition}}


### PR DESCRIPTION
Switched --workdir in the slurm section to be --chdir instead. Slurm 19.05 series removed the --workdir option.