### PR TITLE
Support named servers

### DIFF
--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -18,6 +18,7 @@ class BatchSpawnerAPIHandler(APIHandler):
             if s.api_token == token:
                 spawner = s
                 break
+        data = self.get_json_body()
         for key, value in data.items():
             if hasattr(spawner, key):
                 setattr(spawner, key, value)

--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -13,9 +13,14 @@ class BatchSpawnerAPIHandler(APIHandler):
             # Previous jupyterhub, 0.9.4 and before.
             user = self.get_current_user()
         data = self.get_json_body()
+        if self.allow_named_servers:
+            server_name = data.pop("server_name", "")
+            spawner = user.spawners[server_name]
+        else:
+            spawner = user.spawner
         for key, value in data.items():
-            if hasattr(user.spawner, key):
-                setattr(user.spawner, key, value)
+            if hasattr(spawner, key):
+                setattr(spawner, key, value)
         self.finish(json.dumps({"message": "BatchSpawner data configured"}))
         self.set_status(201)
 

--- a/batchspawner/api.py
+++ b/batchspawner/api.py
@@ -12,12 +12,12 @@ class BatchSpawnerAPIHandler(APIHandler):
         else:
             # Previous jupyterhub, 0.9.4 and before.
             user = self.get_current_user()
-        data = self.get_json_body()
-        if self.allow_named_servers:
-            server_name = data.pop("server_name", "")
-            spawner = user.spawners[server_name]
-        else:
-            spawner = user.spawner
+        token = self.get_auth_token()
+        spawner = None
+        for s in user.spawners.values():
+            if s.api_token == token:
+                spawner = s
+                break
         for key, value in data.items():
             if hasattr(spawner, key):
                 setattr(spawner, key, value)

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -8,6 +8,7 @@ from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
 def main(argv=None):
+    server_name = os.environ.get('JUPYTERHUB_SERVER_NAME', '')
     port = random_port()
     hub_auth = HubAuth()
     hub_auth.client_ca = os.environ.get('JUPYTERHUB_SSL_CLIENT_CA', '')
@@ -15,7 +16,7 @@ def main(argv=None):
     hub_auth.keyfile = os.environ.get('JUPYTERHUB_SSL_KEYFILE', '')
     hub_auth._api_request(method='POST',
                           url=url_path_join(hub_auth.api_url, 'batchspawner'),
-                          json={'port' : port})
+                          json={'server_name': server_name, 'port' : port})
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ['--port={}'.format(port)]

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -8,7 +8,6 @@ from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
 def main(argv=None):
-    server_name = os.environ.get('JUPYTERHUB_SERVER_NAME', '')
     port = random_port()
     hub_auth = HubAuth()
     hub_auth.client_ca = os.environ.get('JUPYTERHUB_SSL_CLIENT_CA', '')
@@ -16,7 +15,7 @@ def main(argv=None):
     hub_auth.keyfile = os.environ.get('JUPYTERHUB_SSL_KEYFILE', '')
     hub_auth._api_request(method='POST',
                           url=url_path_join(hub_auth.api_url, 'batchspawner'),
-                          json={'server_name': server_name, 'port' : port})
+                          json={'port' : port})
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ['--port={}'.format(port)]


### PR DESCRIPTION
Since [v0.8](https://jupyterhub.readthedocs.io/en/stable/changelog.html#id15), JupyterHub has supported "named servers."  If `c.JupyterHub.allow_named_servers=True` in the hub config, servers can have names assigned to them.  If this setting is `False` then there is only one server with the name '' (empty string).

For BatchSpawner to work with named servers, the port selected by `batchspawner-singleuser` must be routed to the right spawner.  Right now the port is attached to `user.spawner` but this is really just an alias for `user.spawners['']`.  Without this fix the port value lands on the empty-string spawner and that may not be what the user wanted to happen at all.

To tell the hub which spawner to attach the port information to, this PR has `batchspawner-singleuser` read the value of the environment variable `JUPYTERHUB_SERVER_NAME` and send it back to the hub as part of the API call.  The API is modified to consume this value and use it to attach the port to the right spawner.