### PR TITLE
Fail hard on first error in batch script

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -504,6 +504,8 @@ class TorqueSpawner(BatchSpawnerRegexStates):
 #PBS -v {keepvars}
 #PBS {options}
 
+set -euo pipefail
+
 {prologue}
 {cmd}
 {epilogue}
@@ -542,6 +544,8 @@ class PBSSpawner(TorqueSpawner):
 #PBS -e {{homedir}}/.jupyterhub.pbs.err
 #PBS -v {{keepvars}}
 {% if options %}#PBS {{options}}{% endif %}
+
+set -euo pipefail
 
 {{prologue}}
 {{cmd}}
@@ -597,6 +601,8 @@ class SlurmSpawner(UserEnvMixin,BatchSpawnerRegexStates):
 {% endif %}{% if nprocs     %}#SBATCH --cpus-per-task={{nprocs}}
 {% endif %}{% if reservation%}#SBATCH --reservation={{reservation}}
 {% endif %}{% if options    %}#SBATCH {{options}}{% endif %}
+
+set -euo pipefail
 
 trap 'echo SIGTERM received' TERM
 {{prologue}}
@@ -670,6 +676,8 @@ class GridengineSpawner(BatchSpawnerBase):
 #$ -e {homedir}/.jupyterhub.sge.err
 #$ -v {keepvars}
 #$ {options}
+
+set -euo pipefail
 
 {prologue}
 {cmd}
@@ -760,6 +768,8 @@ class LsfSpawner(BatchSpawnerBase):
 #BSUB -J spawner-jupyterhub
 #BSUB -o {homedir}/.jupyterhub.lsf.out
 #BSUB -e {homedir}/.jupyterhub.lsf.err
+
+set -euo pipefail
 
 {prologue}
 {cmd}


### PR DESCRIPTION
Bash generally keeps executing code line by line even
if any of the lines fail. For example, if your path is
not set properly, `batchspawner-singleuser` will not
be found by `which`. This should terminate execution.
However, without `set -e`, execution will just continue
and fail with a different error.

This patch does `set -euo pipefail` for all submission
scripts. This causes them to fail on:

1. Any non-zero command return code (-e)
2. On undefined environment variables (-u)
3. Treat failures in any part of a pipeline as failure,
   rather than just the last command (-o pipefail)