### PR TITLE
When checking the job status crashes, do not force empty status, keep…

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -277,7 +277,6 @@ class BatchSpawnerBase(Spawner):
             self.job_status = out
         except Exception as e:
             self.log.error('Error querying job ' + self.job_id)
-            self.job_status = ''
         finally:
             return self.job_status
 


### PR DESCRIPTION
The call to check the status of the job may eventually crash and the reason won't in general be related to the status of the job. In case checking the job status crashes, it makes more sense to keep the previous one.

Our HTCondor batch system may become overloaded for some minutes from time to time. During these periods the condor_q command will always fail and with the current implementation it leads to a submit-kill loop.