### PR TITLE
Introduce unknown job status to handle communication problem with resource manager

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -371,7 +371,7 @@ class BatchSpawnerBase(Spawner):
         if len(self.job_id) == 0:
             raise RuntimeError("Jupyter batch job submission failure (no jobid in output)")
         while True:
-            await self.poll()
+            await self.query_job_status()
             if self.state_isrunning():
                 break
             else:
@@ -415,7 +415,7 @@ class BatchSpawnerBase(Spawner):
         if now:
             return
         for i in range(10):
-            await self.poll()
+            await self.query_job_status()
             if not self.state_isrunning() and not self.state_isunknown():
                 return
             await gen.sleep(1.0)

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -648,7 +648,7 @@ echo "jupyterhub-singleuser ended gracefully"
     #  RUNNING,  COMPLETING = running
     state_pending_re = Unicode(r'^(?:PENDING|CONFIGURING)').tag(config=True)
     state_running_re = Unicode(r'^(?:RUNNING|COMPLETING)').tag(config=True)
-    state_unknown_re = Unicode(r'^slurm_load_jobs error: (?:Socket timed out on send/recv)').tag(config=True)
+    state_unknown_re = Unicode(r'^slurm_load_jobs error: (?:Socket timed out on send/recv|Unable to contact slurm controller)').tag(config=True)
     state_exechost_re = Unicode(r'\s+((?:[\w_-]+\.?)+)$').tag(config=True)
 
     def parse_job_id(self, output):

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -256,13 +256,13 @@ class BatchSpawnerBase(Spawner):
             self.job_id = ''
         return self.job_id
 
-    # Override if your batch system needs something more elaborate to read the job status
+    # Override if your batch system needs something more elaborate to query the job status
     batch_query_cmd = Unicode('',
-        help="Command to run to read job status. Formatted using req_xyz traits as {xyz} "
+        help="Command to run to query job status. Formatted using req_xyz traits as {xyz} "
              "and self.job_id as {job_id}."
         ).tag(config=True)
 
-    async def read_job_state(self):
+    async def query_job_status(self):
         if self.job_id is None or len(self.job_id) == 0:
             # job not running
             self.job_status = ''
@@ -338,7 +338,7 @@ class BatchSpawnerBase(Spawner):
     async def poll(self):
         """Poll the process"""
         if self.job_id is not None and len(self.job_id) > 0:
-            await self.read_job_state()
+            await self.query_job_status()
             if self.state_isrunning() or self.state_ispending() or self.state_isunknown():
                 return None
             else:

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -58,7 +58,7 @@ def format_template(template, *args, **kwargs):
     return template.format(*args, **kwargs)
 
 class JobStatus(Enum):
-    NOTQUEUED  = 0
+    NOTFOUND   = 0
     RUNNING    = 1
     PENDING    = 2
     UNKNOWN    = 3
@@ -272,7 +272,7 @@ class BatchSpawnerBase(Spawner):
     async def query_job_status(self):
         if self.job_id is None or len(self.job_id) == 0:
             self.job_status = ''
-            return JobStatus.NOTQUEUED
+            return JobStatus.NOTFOUND
         subvars = self.get_req_subvars()
         subvars['job_id'] = self.job_id
         cmd = ' '.join((format_template(self.exec_prefix, **subvars),
@@ -293,7 +293,7 @@ class BatchSpawnerBase(Spawner):
         elif self.state_isunknown():
             return JobStatus.UNKNOWN
         else:
-            return JobStatus.NOTQUEUED
+            return JobStatus.NOTFOUND
 
     batch_cancel_cmd = Unicode('',
         help="Command to stop/cancel a previously submitted job. Formatted like batch_query_cmd."

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -416,7 +416,7 @@ class BatchSpawnerBase(Spawner):
             return
         for i in range(10):
             await self.poll()
-            if not self.state_isrunning():
+            if not self.state_isrunning() and not self.state_isunknown():
                 return
             await gen.sleep(1.0)
         if self.job_id:

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -270,6 +270,7 @@ class BatchSpawnerBase(Spawner):
         ).tag(config=True)
 
     async def query_job_status(self):
+        """Check job status, return JobStatus object."""
         if self.job_id is None or len(self.job_id) == 0:
             self.job_status = ''
             return JobStatus.NOTFOUND


### PR DESCRIPTION
This is a draft PR to handle the case where the resource manager does not return a status that is valid for BatchSpawner, but the error message returned indicate a problem with the resource manager and not the job.

This happens quite often with Slurm where squeue would return `slurm_load_jobs error:  Socket timed out on send/recv`. The notebook job is still running fine, squeue was just not able to query its state. Currently, batchspawner will clear the state if it cannot query it, and the job will be subsequently cancelled, which is inconvenient. This problem has been exposed in #171 and #178.

The proposed solution is to refactor the job status querying to return a JobStatus object instead of the job_status string. We introduce four states: NOTQUEUED, RUNNING, PENDING, and UNKNOWN. Because the function deal with job status and not state, the method `read_job_state` is renamed `query_job_status`. This also makes the method names more consistent with the documentation.

Instead of calling the job_is* function, query_status_job returns a JobStatus object which can be used to determine what should be done next. The unknown status is determined by state_isunknown function, and for now only SlurmSpawner implements a regex to handle the cases where the query command exit code is 1.