### PR TITLE
batchspawner/batchspawner: Don't use `-o pipefail` in /bin/sh scripts

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -504,7 +504,7 @@ class TorqueSpawner(BatchSpawnerRegexStates):
 #PBS -v {keepvars}
 #PBS {options}
 
-set -euo pipefail
+set -eu
 
 {prologue}
 {cmd}
@@ -545,7 +545,7 @@ class PBSSpawner(TorqueSpawner):
 #PBS -v {{keepvars}}
 {% if options %}#PBS {{options}}{% endif %}
 
-set -euo pipefail
+set -eu
 
 {{prologue}}
 {{cmd}}
@@ -784,7 +784,7 @@ class LsfSpawner(BatchSpawnerBase):
 #BSUB -o {homedir}/.jupyterhub.lsf.out
 #BSUB -e {homedir}/.jupyterhub.lsf.err
 
-set -euo pipefail
+set -eu
 
 {prologue}
 {cmd}


### PR DESCRIPTION
- `-o pipefail` is a bashism, so that the spawner scripts that use
  `/bin/sh` can't possibly work if it's not linked to bash.  As a
  immediate workaround, remove the option on the non-bash scripts.  A
  long-term plan will come later.
- Closes: #184, Discussion: #184
- Fixes up: #177
- Follow-up in: #188