### PR TITLE
Include version.py and requirements.txt in MANIFEST for sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.md
 include LICENSE
+include version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.md
 include LICENSE
 include version.py
+include requirements.txt


### PR DESCRIPTION
Closes #197 

Tested with `python setup.py sdist`, and then building from source in `dist/`. It worked after I added both `version.py` and `requirements.txt` to `MANIFEST`.

Tested too that `python setup.py bdist_wheel` did not include these files.