### PR TITLE
Improve submit_batch_script logging

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -278,14 +278,16 @@ class BatchSpawnerBase(Spawner):
         if hasattr(self, "user_options"):
             subvars.update(self.user_options)
         script = await self._get_batch_script(**subvars)
-        self.log.info("Spawner submitting job using " + cmd)
-        self.log.info("Spawner submitted script:\n" + script)
+        self.log.info("Spawner script options: %s", subvars)
+        self.log.info("Spawner submitting command: %s", cmd)
+        self.log.debug("Spawner submitting script:\n%s", script)
+        self.log.debug("Spawner submitting environment: %s", self.get_env())
         out = await self.run_command(cmd, input=script, env=self.get_env())
         try:
-            self.log.info("Job submitted. cmd: " + cmd + " output: " + out)
+            self.log.info("Job submitted. output: %s", out)
             self.job_id = self.parse_job_id(out)
         except:
-            self.log.error("Job submission failed with exit code " + out)
+            self.log.error("Job submission failed. exit code: %s", out)
             self.job_id = ""
         return self.job_id
 


### PR DESCRIPTION
Adds:
- logging of `subvars` (info)
- logging of `self.get_env` (debug)

Changes:
- the logging level of the submit script from `info` to `debug`. 

The rational is that it is easier to parse `subvars` dictionary in a separate log than the multiline submit script, which would then be only useful in a debug context.

Removes:
- `cmd` from the `Job submitted` info log, since it is was already logged before.

This PR also introduces the usage of logging argument instead of concatenating string with `+`.
I will follow with a second PR that standardize logging to use argument instead of string concatenation systematically.