### PR TITLE
Remove code no longer used

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -16,11 +16,10 @@ Common attributes of batch submission / resource manager environments will inclu
   * job names instead of PIDs
 """
 import asyncio
-from async_generator import async_generator, yield_, yield_from_
+from async_generator import async_generator, yield_
 import pwd
 import os
 import re
-import sys
 
 import xml.etree.ElementTree as ET
 
@@ -29,15 +28,10 @@ from enum import Enum
 from jinja2 import Template
 
 from tornado import gen
-from tornado.process import Subprocess
-from subprocess import CalledProcessError
-from tornado.iostream import StreamClosedError
 
 from jupyterhub.spawner import Spawner
-from jupyterhub.traitlets import Command
 from traitlets import Integer, Unicode, Float, Dict, default
 
-from jupyterhub.utils import random_port
 from jupyterhub.spawner import set_user_setuid
 import jupyterhub
 

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -33,7 +33,6 @@ from jupyterhub.spawner import Spawner
 from traitlets import Integer, Unicode, Float, Dict, default
 
 from jupyterhub.spawner import set_user_setuid
-import jupyterhub
 
 
 def format_template(template, *args, **kwargs):
@@ -416,7 +415,7 @@ class BatchSpawnerBase(Spawner):
         self.ip = self.traits()["ip"].default_value
         self.port = self.traits()["port"].default_value
 
-        if jupyterhub.version_info >= (0, 8) and self.server:
+        if self.server:
             self.server.port = self.port
 
         job = await self.submit_batch_script()
@@ -460,10 +459,6 @@ class BatchSpawnerBase(Spawner):
             if hasattr(self, "mock_port"):
                 self.port = self.mock_port
 
-        if jupyterhub.version_info < (0, 7):
-            # store on user for pre-jupyterhub-0.7:
-            self.user.server.port = self.port
-            self.user.server.ip = self.ip
         self.db.commit()
         self.log.info(
             "Notebook server job {0} started at {1}:{2}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 async_generator>=1.8
 jinja2
-jupyterhub>=0.5
+jupyterhub>=0.9

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_args = dict(
     url="http://jupyter.org",
     license="BSD",
     platforms="Linux, Mac OS X",
-    python_requires="~=3.3",
+    python_requires="~=3.5",
     keywords=["Interactive", "Interpreter", "Shell", "Web", "Jupyter"],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
Considering batchspawner now requires jupyterhub >= 0.9, this PR removes code that ran only for JH < 0.9.

This PR also removes imports that are no longer used and bumped requirements in requirements.txt and setup.py.