### PR TITLE
LSF jobs with multiple slots display each hostname ':' separated

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -980,7 +980,7 @@ set -eu
 
     def state_gethost(self):
         if self.job_status:
-            return self.job_status.split(" ")[1].strip()
+            return self.job_status.split(" ")[1].strip().split(":")[0]
 
         self.log.error(
             "Spawner unable to match host addr in job {0} with status {1}".format(


### PR DESCRIPTION
Bug description

I believe old LSF implementations used space node names where a job was submitted to multiple machines. bjobs now returns a host multiple times, seperated by a ':' if more than one slot is used on a node. This means the state_gethost no longer works on LSF when using more than one cpu.
Expected behaviour

Using more than one slot should work.
Actual behaviour

Using more than one slot does not work.
How to reproduce

Have an LSF 10.1 cluster and try and use LSF with more than one slot.
Your personal set up

LSF 10.1 on ubuntu 18.04

https://github.com/jupyterhub/batchspawner/issues/228