### PR TITLE
Replace use of scripts with entry_points

### DIFF
--- a/scripts/batchspawner-singleuser
+++ b/scripts/batchspawner-singleuser
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-from batchspawner.singleuser import main
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ with open(pjoin(here, "README.md"), encoding="utf-8") as f:
 
 setup_args = dict(
     name="batchspawner",
-    scripts=glob(pjoin("scripts", "*")),
+    entry_points={
+        "console_scripts": ["batchspawner-singleuser=batchspawner.singleuser:main"],
+    },
     packages=["batchspawner"],
     version=version_ns["__version__"],
     description="""Batchspawner: A spawner for Jupyterhub to spawn notebooks using batch resource managers.""",


### PR DESCRIPTION
## References

- fixes #235

## Changes
- [x] replaces use of `scripts` with `entry_points: console_scripts`
  - this generally generates better/more secure scripts that are more predictable for downstream packagers e.g. debian, conda-forge
  - also more cross-platform-compatible, which is a story for another day...