### PR TITLE
bump pre-commit black to stable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 repos:
   # Autoformat: Python code
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: "22.3.0"
     hooks:
       - id: black
         args: [--target-version=py36]


### PR DESCRIPTION
## References

- noticed on #237

## Changes

- [x] bumps to stable black
  - this version is compatible with the unmanaged transient dependencies (click, etc) that pre-commit brings along