### PR TITLE
ci: fix broken tests by not installing pre-releases of jh's dev-requirements.txt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,20 +60,21 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           pip install -r requirements.txt
+          pip list
+
       - name: Install nodejs dependencies
         run: |
           sudo npm install -g configurable-http-proxy
 
-      # We need to check compatibility with different versions of the JH
-      # API, including latest development.  For that, we also need to
-      # pull in the dependencies of that old JH version (but we don't
-      # need conda/npm for our tests).
+      # We need to check compatibility with different versions of the JH API,
+      # including latest development.  For that, we also need to pull in the
+      # development dependencies of that old JH version (but we don't need
+      # conda/npm for our tests).
       - name: install JupyterHub
         run: |
-          git clone --quiet --branch ${{ matrix.JHUB_VER }} https://github.com/jupyterhub/jupyterhub.git jupyterhub
-          pip install --pre -r jupyterhub/dev-requirements.txt
-          pip install --upgrade pytest
-          pip install --pre -e jupyterhub
+          git clone --quiet --branch ${{ matrix.JHUB_VER }} https://github.com/jupyterhub/jupyterhub.git ./jupyterhub
+          pip install -r ./jupyterhub/dev-requirements.txt
+          pip install ./jupyterhub
 
       - name: pytest
         run: |

--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ error messages:
   batchspawner-specific, with the one exception below. The error log
   would be in the batch script output (same file as above). There may
   also be clues in the JupyterHub logfile.
-  
-- Are you running on an NFS filesystem? It's possible for Jupyter to 
+- Are you running on an NFS filesystem? It's possible for Jupyter to
   experience issues due to varying implementations of the fcntl() system
   call. (See also [Jupyterhub-Notes and Tips: SQLite](https://jupyterhub.readthedocs.io/en/latest/reference/database.html?highlight=NFS#sqlite))
 

--- a/batchspawner/tests/conftest.py
+++ b/batchspawner/tests/conftest.py
@@ -1,3 +1,10 @@
-"""py.test fixtures imported from Jupyterhub testing"""
+"""Relevant pytest fixtures are re-used from JupyterHub's test suite"""
 
-from jupyterhub.tests.conftest import *
+# We only use "db" and "io_loop", but we also need event_loop which is used by
+# io_loop to be available with jupyterhub 1+.
+from jupyterhub.tests.conftest import db, io_loop
+
+try:
+    from jupyterhub.tests.conftest import event_loop
+except:
+    pass


### PR DESCRIPTION
We had CI test failures, they are resolved by this PR.