### PR TITLE
SlurmSpawner: add --nodes=1 --ntasks=1

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -693,6 +693,7 @@ class SlurmSpawner(UserEnvMixin, BatchSpawnerRegexStates):
 #SBATCH --chdir={{homedir}}
 #SBATCH --export={{keepvars}}
 #SBATCH --get-user-env=L
+#SBATCH --nodes=1 --ntasks=1
 {% if partition  %}#SBATCH --partition={{partition}}
 {% endif %}{% if runtime    %}#SBATCH --time={{runtime}}
 {% endif %}{% if memory     %}#SBATCH --mem={{memory}}


### PR DESCRIPTION
We've had a few cases where requests for multiple GPUs ended up allocating multiple nodes, which obviously causes weird problems.  Obviously we could configure our partition and options to prevent this, but since in general I can't think of any case where you'd want to run multiple tasks or nodes, it seems nice to constrain it here (PBS already seems to do this).  Either `--ntasks=1` or `--nodes=1` should be enough but both shouldn't hurt.  (If I'm wrong and there's some use cases where you want -N2 or -n2 or something please correct me.)