### PR TITLE
Quell async warning, and POST with body for jupyterhub 3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,6 @@ repos:
       # Lint: Checks that non-binary executables have a proper shebang.
       - id: check-executables-have-shebangs
 
-
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:
   autoupdate_schedule: monthly

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 
@@ -7,6 +8,7 @@ from shutil import which
 from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
+from tornado.escape import json_encode
 
 def main(argv=None):
     port = random_port()
@@ -14,10 +16,12 @@ def main(argv=None):
     hub_auth.client_ca = os.environ.get("JUPYTERHUB_SSL_CLIENT_CA", "")
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
-    hub_auth._api_request(
-        method="POST",
-        url=url_path_join(hub_auth.api_url, "batchspawner"),
-        json={"port": port},
+    asyncio.run(
+        hub_auth._api_request(
+            method="POST",
+            url=url_path_join(hub_auth.api_url, "batchspawner"),
+            body=json_encode({"port": port})
+        )
     )
 
     cmd_path = which(sys.argv[1])

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -10,6 +10,7 @@ from jupyterhub.services.auth import HubAuth
 
 from tornado.escape import json_encode
 
+
 def main(argv=None):
     port = random_port()
     hub_auth = HubAuth()
@@ -20,7 +21,7 @@ def main(argv=None):
         hub_auth._api_request(
             method="POST",
             url=url_path_join(hub_auth.api_url, "batchspawner"),
-            body=json_encode({"port": port})
+            body=json_encode({"port": port}),
         )
     )
 


### PR DESCRIPTION
I upgraded a development hub to jupyterhub 3.0.0b1 from 1.5.x and ran into a couple of issues. I'm using slurm and these issues were present with the latest release and latest in git:

Initially I was seeing the following warning:
```
/usr/local/linux/anaconda3.8/envs/jupyterhub-3.0/lib/python3.8/site-packages/batchspawner/singleuser.py:16: RuntimeWarning: coroutine 'HubAuth._api_request' was never awaited
  hub_auth._api_request(method='POST',
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
[I 2022-08-19 23:32:20.510 SingleUserLabApp mixins:610] Starting jupyterhub single-user server version 3.0.0b1
...
```

It did start the server, however the hub wouldn't redirect me to it.

This patch quells the warning, but more importantly causes hub to redirect me to the server properly. I don't know if anyone else has been able to use batchspawner as-is with jupyterhub 3.0.0b1.

This also updates the api request call to post data via the `body` parameter which seems like the right way to do that now according to tornado HTTPRequest docs.
