### PR TITLE
Remote spawned server running but ... waiting to connect

### DIFF
--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -7,6 +7,8 @@ from shutil import which
 from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
+import asyncio
+import json
 
 def main(argv=None):
     port = random_port()
@@ -14,10 +16,12 @@ def main(argv=None):
     hub_auth.client_ca = os.environ.get("JUPYTERHUB_SSL_CLIENT_CA", "")
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
-    hub_auth._api_request(
-        method="POST",
-        url=url_path_join(hub_auth.api_url, "batchspawner"),
-        json={"port": port},
+    asyncio.run(
+	hub_auth._api_request(
+        	method="POST",
+        	url=url_path_join(hub_auth.api_url, "batchspawner"),
+        	body=json.dumps({"port": port})
+    	)
     )
 
     cmd_path = which(sys.argv[1])

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -10,6 +10,7 @@ from jupyterhub.services.auth import HubAuth
 import asyncio
 import json
 
+
 def main(argv=None):
     port = random_port()
     hub_auth = HubAuth()
@@ -17,11 +18,11 @@ def main(argv=None):
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
     asyncio.run(
-	hub_auth._api_request(
-        	method="POST",
-        	url=url_path_join(hub_auth.api_url, "batchspawner"),
-        	body=json.dumps({"port": port})
-    	)
+        hub_auth._api_request(
+            method="POST",
+            url=url_path_join(hub_auth.api_url, "batchspawner"),
+            body=json.dumps({"port": port}),
+        )
     )
 
     cmd_path = which(sys.argv[1])

--- a/version.py
+++ b/version.py
@@ -5,6 +5,6 @@ version_info = (
     1,
     2,
     0,
-#    "dev",  # comment-out this line for a release
+    #    "dev",  # comment-out this line for a release
 )
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
JupyterHub vers. 3.0.0 (python 3.9.7) -- Batchspawner for GridEngine successfully submits the remote server task, the job starts and binds to a reachable port, the Hub acknowledges the running job, but reports "...waiting to connect" and remains this way until (300sec) timeout (then successfully deletes the running job). 
Turns out the Hub never receives the random port number generated in the /barchspawner/singleuser.py, run by the spawned job, because the _api_request method was never awaited (a discrete warning is posted in the spawner log).

This suggested fix adds a proper call to the now __api_request_ async method, and also changes the payload format to match the expected _HTTPRequest_ arguments.

