### PR TITLE
Upgrade `singleuser.py` for JupyterHub 3

### DIFF
--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,11 +1,16 @@
 import os
 import sys
+import json
+import asyncio
 
 from runpy import run_path
 from shutil import which
 
+import jupyterhub
 from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
+
+JH_MAJOR_VERSION, _, _ = jupyterhub.__version__.split('.')
 
 
 def main(argv=None):
@@ -14,11 +19,24 @@ def main(argv=None):
     hub_auth.client_ca = os.environ.get("JUPYTERHUB_SSL_CLIENT_CA", "")
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
-    hub_auth._api_request(
-        method="POST",
-        url=url_path_join(hub_auth.api_url, "batchspawner"),
-        json={"port": port},
-    )
+    if int(JH_MAJOR_VERSION) < 3:
+        hub_auth._api_request(
+            method="POST",
+            url=url_path_join(hub_auth.api_url, "batchspawner"),
+            json={"port": port},
+        )
+    else:
+        # Starting from JupyterHub 3.0.0, the method _api_request is
+        # asynchronous. Consequently the request is made using ASyncHTTPClient
+        # and hence json argument is no longer valid. We need to change it to
+        # body and encode it.
+        asyncio.run(
+            hub_auth._api_request(
+                method="POST",
+                url=url_path_join(hub_auth.api_url, "batchspawner"),
+                body=json.dumps({"port": port}),
+            )
+        )
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ["--port={}".format(port)]

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -10,7 +10,7 @@ import jupyterhub
 from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
-JH_MAJOR_VERSION, _, _ = jupyterhub.__version__.split('.')
+JH_MAJOR_VERSION, _, _ = jupyterhub.__version__.split(".")
 
 
 def main(argv=None):

--- a/version.py
+++ b/version.py
@@ -5,6 +5,6 @@ version_info = (
     1,
     2,
     0,
-#    "dev",  # comment-out this line for a release
+    #    "dev",  # comment-out this line for a release
 )
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
The [`_api_request`](https://github.com/jupyterhub/jupyterhub/blob/3.0.0/jupyterhub/services/auth.py#L456-L542) method of `HubAuth` in JupyterHub 3 is made into a coroutine. So, `batchspawner-singleuser` in its current implementation will fail to communicate with JupyterHub as request is never awaited. 

This PR modifies the `singleuser.py` function to make it work for JupyterHub 2 and 3.