### PR TITLE
Fix to work with _api_request from Jupyterhub > 3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,6 @@ repos:
       # Lint: Checks that non-binary executables have a proper shebang.
       - id: check-executables-have-shebangs
 
-
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:
   autoupdate_schedule: monthly

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import asyncio
+import json
 
 from runpy import run_path
 from shutil import which
@@ -14,11 +16,11 @@ def main(argv=None):
     hub_auth.client_ca = os.environ.get("JUPYTERHUB_SSL_CLIENT_CA", "")
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
-    hub_auth._api_request(
+    asyncio.run(hub_auth._api_request(
         method="POST",
         url=url_path_join(hub_auth.api_url, "batchspawner"),
-        json={"port": port},
-    )
+        body=json.dumps({"port": port})
+    ))
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ["--port={}".format(port)]

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -16,11 +16,13 @@ def main(argv=None):
     hub_auth.client_ca = os.environ.get("JUPYTERHUB_SSL_CLIENT_CA", "")
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
-    asyncio.run(hub_auth._api_request(
-        method="POST",
-        url=url_path_join(hub_auth.api_url, "batchspawner"),
-        body=json.dumps({"port": port})
-    ))
+    asyncio.run(
+        hub_auth._api_request(
+            method="POST",
+            url=url_path_join(hub_auth.api_url, "batchspawner"),
+            body=json.dumps({"port": port}),
+        )
+    )
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ["--port={}".format(port)]


### PR DESCRIPTION
After upgrading to Jupyterhub > 3, running batchspawner-singleuser produces the error:
```
/opt/conda/lib/python3.11/site-packages/batchspawner/singleuser.py:17: RuntimeWarning: coroutine 'HubAuth._api_request' was never awaited
  hub_auth._api_request(
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```
and the singleuser server never makes contact with the jupyterhub server. Issues #233 and #253 may be related to this.

The source of the problem is that Jupyterhub refactored the routines in services.auth to allow them to work with async code. Connected to that, they switched from using requests to tornado.HTTPClient. This was supposed to be a transparent and non-breaking change, but batchspawner-singleuser cheats by calling an internal function (`_api_request`) and pays the price!

This PR just wraps the call to `_api_request` in `asyncio.run()` and replaces the `json=` arg with `body=`. 