### PR TITLE
Fix Slurm test used regular expression

### DIFF
--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -476,11 +476,11 @@ async def test_slurm(db, event_loop):
         re.compile(
             r"PROLOGUE.*srun batchspawner-singleuser singleuser_command.*EPILOGUE", re.S
         ),
-        re.compile(r"^#SBATCH \s+ --cpus-per-task=5", re.X | re.M),
-        re.compile(r"^#SBATCH \s+ --time=3-05:10:10", re.X | re.M),
-        re.compile(r"^#SBATCH \s+ some_option_asdf", re.X | re.M),
-        re.compile(r"^#SBATCH \s+ --reservation=RES123", re.X | re.M),
-        re.compile(r"^#SBATCH \s+ --gres=GRES123", re.X | re.M),
+        re.compile(r"^\#SBATCH \s+ --cpus-per-task=5", re.X | re.M),
+        re.compile(r"^\#SBATCH \s+ --time=3-05:10:10", re.X | re.M),
+        re.compile(r"^\#SBATCH \s+ some_option_asdf", re.X | re.M),
+        re.compile(r"^\#SBATCH \s+ --reservation=RES123", re.X | re.M),
+        re.compile(r"^\#SBATCH \s+ --gres=GRES123", re.X | re.M),
     ]
     from .. import SlurmSpawner
 


### PR DESCRIPTION
This PR fixes the regular expressions used to validate the submitted batch script.

Indeed according to [re.X](https://docs.python.org/3.10/library/re.html#re.VERBOSE) documentation:
> When a line contains a # that is not in a character class and is not preceded by an unescaped backslash, all characters from the leftmost such # through the end of the line are ignored.

So all regular expressions were matching to the line start.