### PR TITLE
Change port number for JUPYTERHUB_SERVICE_URL

### DIFF
--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -37,12 +37,14 @@ def main(argv=None):
     )
 
     # Change the port number for the environment variable JUPYTERHUB_SERVICE_URL
-    url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
-    url_netloc = url.netloc.split(':')
+    url = urlparse(os.environ["JUPYTERHUB_SERVICE_URL"])
+    url_netloc = url.netloc.split(":")
 
     if len(url_netloc) == 2:
         url_netloc[1] = str(port)
-    os.environ["JUPYTERHUB_SERVICE_URL"] = urlunparse(url._replace(netloc=':'.join(url_netloc)))
+    os.environ["JUPYTERHUB_SERVICE_URL"] = urlunparse(
+        url._replace(netloc=":".join(url_netloc))
+    )
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ["--port={}".format(port)]

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -7,6 +7,8 @@ from shutil import which
 from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
+from urllib.parse import urlparse, urlunparse
+
 import requests
 
 
@@ -33,6 +35,14 @@ def main(argv=None):
         json={"port": port},
         **kwargs,
     )
+
+    # Change the port number for the environment variable JUPYTERHUB_SERVICE_URL
+    url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
+    url_netloc = url.netloc.split(':')
+
+    if len(url_netloc) == 2:
+        url_netloc[1] = str(port)
+    os.environ["JUPYTERHUB_SERVICE_URL"] = urlunparse(url._replace(netloc=':'.join(url_netloc)))
 
     cmd_path = which(sys.argv[1])
     sys.argv = sys.argv[1:] + ["--port={}".format(port)]


### PR DESCRIPTION
JupyterHub will add extensions to Jupyter ServerApp to configure some settings. It seems that newer versions of JupyterHub extensions will check the environment variable JUPYTERHUB_SERVICE_URL to determine the port and the base URL of the ServerApp and override the randomly generated port given in the batchspawner-singleuser.py file. 

Therefore, I added some code to change the port of the JUPYTERHUB_SERVICE_URL variable before it is exported to the target machine. Since my setup uses base URL 0.0.0.0 (which is the default value), I do not need to change the base URL of the environment variable. Further modification might be needed to accommodate that. 