### PR TITLE
Add information about bug with JupyterHub 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package formerly included WrapSpawner and ProfilesSpawner, which provide me
 
 > **⚠ NOTE**
 >
-> If you are using JupyterHub 3+ then you currently must install using the `pip install -e` method, due to a bug that [will be fixed](https://github.com/jupyterhub/batchspawner/issues/277) in the next release.
+> If you are using JupyterHub 3+ then you currently must install from the main branch, for example by `pip install https://github.com/jupyterhub/batchspawner/archive/main.zip`, due to a [bug that is resolved but not yet released](https://github.com/jupyterhub/batchspawner/issues/277).
 
 1. from root directory of this repo (where setup.py is), run `pip install -e .`
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This package formerly included WrapSpawner and ProfilesSpawner, which provide me
 
 ## Installation
 
+> **⚠ NOTE**
+> 
+> If you are using JupyterHub 3+ then you currently must install using the `pip install -e` method, due to a bug that [will be fixed](https://github.com/jupyterhub/batchspawner/issues/277) in the next release.
+
 1. from root directory of this repo (where setup.py is), run `pip install -e .`
 
    If you don't actually need an editable version, you can simply run

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package formerly included WrapSpawner and ProfilesSpawner, which provide me
 ## Installation
 
 > **⚠ NOTE**
-> 
+>
 > If you are using JupyterHub 3+ then you currently must install using the `pip install -e` method, due to a bug that [will be fixed](https://github.com/jupyterhub/batchspawner/issues/277) in the next release.
 
 1. from root directory of this repo (where setup.py is), run `pip install -e .`


### PR DESCRIPTION
There is a very insidious bug in the currently released version on PyPI (1.2.0) which causes things to break on newer JupyterHub instances without any errors or warnings. Adding a simple warning to the README will warn users about how to proceed, until 1.3.0 is released. 