### PR TITLE
TST: don't assume test user is OS user

### DIFF
--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -1,8 +1,11 @@
 """Test BatchSpawner and subclasses"""
 
 import asyncio
+import pwd
 import re
 import time
+from getpass import getuser
+from unittest import mock
 
 import pytest
 from jupyterhub import orm
@@ -15,6 +18,15 @@ from .. import BatchSpawnerRegexStates, JobStatus
 testhost = "userhost123"
 testjob = "12345"
 testport = 54321
+
+
+@pytest.fixture(autouse=True)
+def _always_get_my_home():
+    # pwd.getbwnam() is always called with the current user
+    # ignoring the requested name, which usually doesn't exist
+    getpwnam = pwd.getpwnam
+    with mock.patch.object(pwd, "getpwnam", lambda name: getpwnam(getuser())):
+        yield
 
 
 class BatchDummy(BatchSpawnerRegexStates):


### PR DESCRIPTION
mock getpwnam to always return result for current user

since test user may well not exist on the system

In particular, JupyterHub 5 test utilities no longer create a test user with the running user's name, which is causing tests to fail, since so far batchspawner tests have assumed that the first user in the database matches `getpass.getuser()`.