### PR TITLE
remove argument to --get-user-env option

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -679,7 +679,7 @@ class SlurmSpawner(UserEnvMixin, BatchSpawnerRegexStates):
 #SBATCH --job-name=spawner-jupyterhub
 #SBATCH --chdir={{homedir}}
 #SBATCH --export={{keepvars}}
-#SBATCH --get-user-env=L
+#SBATCH --get-user-env
 {% if partition  %}#SBATCH --partition={{partition}}
 {% endif %}{% if runtime    %}#SBATCH --time={{runtime}}
 {% endif %}{% if memory     %}#SBATCH --mem={{memory}}


### PR DESCRIPTION
The `--get-user-env` of the `sbatch` from version SLURM version 25.05 onwards does no longer take any arguments. This patch simply removes the argument.

Fixes #319 