### PR TITLE
remove "unknown" job state, simplify poll logic

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -43,8 +43,7 @@ def format_template(template, *args, **kwargs):
 
 class JobStatus(Enum):
     NOTFOUND = 0
-    RUNNING = 1
-    PENDING = 2
+    RUN_OR_PEND = 1
 
 
 class BatchSpawnerBase(Spawner):
@@ -320,12 +319,10 @@ class BatchSpawnerBase(Spawner):
             self.log.error("Error querying job " + self.job_id)
             self.job_status = ""
 
-        if self.state_isrunning():
-            return JobStatus.RUNNING
-        elif self.state_ispending():
-            return JobStatus.PENDING
-        else:
+        if self.state_notfound():
             return JobStatus.NOTFOUND
+        else:
+            return JobStatus.RUN_OR_PEND
 
     batch_cancel_cmd = Unicode(
         "",
@@ -419,16 +416,9 @@ class BatchSpawnerBase(Spawner):
             )
         while True:
             status = await self.query_job_status()
-            if status == JobStatus.RUNNING:
-                break
-            elif status == JobStatus.PENDING:
-                self.log.debug("Job " + self.job_id + " still pending")
-            else:
+            if status == JobStatus.NOTFOUND:
                 self.log.warning(
-                    "Job "
-                    + self.job_id
-                    + " neither pending nor running.\n"
-                    + self.job_status
+                    "Job " + self.job_id + " not found."
                 )
                 self.clear_state()
                 raise RuntimeError(
@@ -436,6 +426,19 @@ class BatchSpawnerBase(Spawner):
                     " while pending in the queue or died immediately"
                     " after starting."
                 )
+            else: # JobStatus.RUN_OR_PEND
+                if self.state_isrunning():
+                    break
+                elif self.state_ispending():
+                    self.log.debug("Job " + self.job_id + " still pending")
+                else:
+                    self.log.warning(
+                        "Job "
+                        + self.job_id
+                        + " neither pending nor running.\n"
+                        + self.job_status
+                    )
+
             await asyncio.sleep(self.startup_poll_interval)
 
         self.ip = self.state_gethost()
@@ -494,11 +497,13 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
     to interact with batch submission system state. Provides implementations of
         state_ispending
         state_isrunning
+        state_notfound
         state_gethost
 
     In their place, the user should supply the following configuration:
         state_pending_re - regex that matches job_status if job is waiting to run
         state_running_re - regex that matches job_status if job is running
+        state_notfound_re - regex that matches job_status if job is not found
         state_exechost_re - regex with at least one capture group that extracts
                             execution host from job_status
         state_exechost_exp - if empty, notebook IP will be set to the contents of the
@@ -515,6 +520,10 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
         "",
         help="Regex that matches job_status if job is running",
     ).tag(config=True)
+    state_notfound_re = Unicode(
+        "",
+        help="Regex that matches job_status if job is not found",
+    ).tag(config=True)
     state_exechost_re = Unicode(
         "",
         help="Regex with at least one capture group that extracts "
@@ -530,12 +539,16 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
     ).tag(config=True)
 
     def state_ispending(self):
-        assert self.state_pending_re, "Misconfigured: define state_running_re"
+        assert self.state_pending_re, "Misconfigured: define state_pending_re"
         return self.job_status and re.search(self.state_pending_re, self.job_status)
 
     def state_isrunning(self):
         assert self.state_running_re, "Misconfigured: define state_running_re"
         return self.job_status and re.search(self.state_running_re, self.job_status)
+
+    def state_notfound(self):
+        assert self.state_notfound_re, "Misconfigured: define state_notfound_re"
+        return self.job_status and re.search(self.state_notfound_re, self.job_status)
 
     def state_gethost(self):
         assert self.state_exechost_re, "Misconfigured: define state_exechost_re"
@@ -713,6 +726,7 @@ echo "jupyterhub-singleuser ended gracefully"
     #  RUNNING,  COMPLETING = running
     state_pending_re = Unicode(r"^(?:PENDING|CONFIGURING)").tag(config=True)
     state_running_re = Unicode(r"^(?:RUNNING|COMPLETING)").tag(config=True)
+    state_notfound_re = Unicode(r'slurm_load_jobs error: Invalid job id specified').tag(config=True)
     state_exechost_re = Unicode(r"\s+((?:[\w_-]+\.?)+)$").tag(config=True)
 
     def parse_job_id(self, output):

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -223,9 +223,10 @@ class BatchSpawnerBase(Spawner):
         run_cmd_id = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
         try:
             out, eout = await proc.communicate(input=inbytes)
-        except:
+        except Exception as e:
             self.log.error(f"run_command id {run_cmd_id}")
-            self.log.error(f"{run_cmd_id} Exception raised when trying to run command: {cmd}")
+            self.log.error(f"{run_cmd_id} Exception {e.__class__.__name__}: {e}")
+            self.log.error(f"{run_cmd_id} exception raised when trying to run command: {cmd}")
             proc.kill()
             self.log.error(f"{run_cmd_id} Running command failed, killed process.")
             try:

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -26,6 +26,8 @@ from jinja2 import Template
 from jupyterhub.spawner import Spawner, set_user_setuid
 from traitlets import Dict, Float, Integer, Unicode, default
 
+import random, string
+
 
 def format_template(template, *args, **kwargs):
     """Format a template, either using jinja2 or str.format().
@@ -218,39 +220,38 @@ class BatchSpawnerBase(Spawner):
         if input:
             inbytes = input.encode()
 
+        run_cmd_id = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
         try:
             out, eout = await proc.communicate(input=inbytes)
         except:
-            self.log.debug("Exception raised when trying to run command: %s" % cmd)
+            self.log.error(f"run_command id {run_cmd_id}")
+            self.log.error(f"{run_cmd_id} Exception raised when trying to run command: {cmd}")
             proc.kill()
-            self.log.debug("Running command failed, killed process.")
+            self.log.error(f"{run_cmd_id} Running command failed, killed process.")
             try:
-                out, eout = await asyncio.wait_for(proc.communicate(), timeout=2)
+                out, eout = await asyncio.wait_for(proc.communicate(), timeout=10)
                 out = out.decode().strip()
                 eout = eout.decode().strip()
-                self.log.error("Subprocess returned exitcode %s" % proc.returncode)
-                self.log.error("Stdout:")
-                self.log.error(out)
-                self.log.error("Stderr:")
-                self.log.error(eout)
-                raise RuntimeError(f"{cmd} exit status {proc.returncode}: {eout}")
-            except asyncio.TimeoutError:
+                self.log.error(f"{run_cmd_id} Subprocess returned exitcode {proc.returncode}")
+                self.log.error(f"{run_cmd_id} Stdout: {out}")
+                self.log.error(f"{run_cmd_id} Stderr: {eout}")
+                raise RuntimeError(f"{run_cmd_id} {cmd} exit status {proc.returncode} stdout: {out} stderr: {eout}")
+            except TimeoutError:
                 self.log.error(
-                    "Encountered timeout trying to clean up command, process probably killed already: %s"
-                    % cmd
+                    f"{run_cmd_id} Encountered timeout trying to clean up command, process probably killed already: {cmd}"
                 )
                 return ""
             except:
                 self.log.error(
-                    "Encountered exception trying to clean up command: %s" % cmd
+                    f"{run_cmd_id} Encountered exception trying to clean up command: {cmd}"
                 )
                 raise
         else:
             eout = eout.decode().strip()
             err = proc.returncode
             if err != 0:
-                self.log.error("Subprocess returned exitcode %s" % err)
-                self.log.error(eout)
+                self.log.error(f"{run_cmd_id} Subprocess returned exitcode {err}")
+                self.log.error(f"{run_cmd_id} stderr {eout}")
                 raise RuntimeError(eout)
 
         out = out.decode().strip()

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -388,7 +388,7 @@ class BatchSpawnerBase(Spawner):
         and return 0.
         """
         status = await self.query_job_status()
-        if not self.job_id:
+        if not status.value:
             self.clear_state()
             return 0
         else:
@@ -467,7 +467,7 @@ class BatchSpawnerBase(Spawner):
             return
         for i in range(10):
             status = await self.query_job_status()
-            if status is not JobStatus.RUNNING:
+            if not status.value: # status.value = 0 (NOTFOUND)
                 return
             await asyncio.sleep(1)
         if self.job_id:

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -208,6 +208,9 @@ class BatchSpawnerBase(Spawner):
         return " ".join([self.batchspawner_singleuser_cmd] + self.cmd + self.get_args())
 
     async def run_command(self, cmd, input=None, env=None):
+        run_cmd_id = get_self_id(self)
+        self.log.error(f"{run_cmd_id} running command {cmd}")
+        
         proc = await asyncio.create_subprocess_shell(
             cmd,
             env=env,
@@ -220,11 +223,9 @@ class BatchSpawnerBase(Spawner):
         if input:
             inbytes = input.encode()
 
-        run_cmd_id = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
         try:
             out, eout = await proc.communicate(input=inbytes)
         except Exception as e:
-            self.log.error(f"run_command id {run_cmd_id}")
             self.log.error(f"{run_cmd_id} Exception {e.__class__.__name__}: {e}")
             self.log.error(f"{run_cmd_id} exception raised when trying to run command: {cmd}")
             proc.kill()
@@ -284,7 +285,9 @@ class BatchSpawnerBase(Spawner):
         self.log.debug("Spawner submitting environment: %s", self.get_env())
         out = await self.run_command(cmd, input=script, env=self.get_env())
         try:
+            run_cmd_id = get_self_id(self)
             self.log.info("Job submitted. output: %s", out)
+            self.log.error(f"{run_cmd_id} job submitted, output: {out}")
             self.job_id = self.parse_job_id(out)
         except:
             self.log.error("Job submission failed. exit code: %s", out)
@@ -466,6 +469,8 @@ class BatchSpawnerBase(Spawner):
         Returns immediately after sending job cancellation command if now=True, otherwise
         tries to confirm that job is no longer running."""
 
+        run_cmd_id = get_self_id(self)
+        self.log.error(f"{run_cmd_id} stopping server job {self.job_id}")
         self.log.info("Stopping server job " + self.job_id)
         await self.cancel_batch_job()
         if now:
@@ -564,6 +569,9 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
             return match.groups()[0]
         else:
             return match.expand(self.state_exechost_exp)
+
+    def get_self_id(self):
+        return id(self)
 
 
 class TorqueSpawner(BatchSpawnerRegexStates):

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -45,7 +45,6 @@ class JobStatus(Enum):
     NOTFOUND = 0
     RUNNING = 1
     PENDING = 2
-    UNKNOWN = 3
 
 
 class BatchSpawnerBase(Spawner):
@@ -325,8 +324,6 @@ class BatchSpawnerBase(Spawner):
             return JobStatus.RUNNING
         elif self.state_ispending():
             return JobStatus.PENDING
-        elif self.state_isunknown():
-            return JobStatus.UNKNOWN
         else:
             return JobStatus.NOTFOUND
 
@@ -380,10 +377,6 @@ class BatchSpawnerBase(Spawner):
         "Return boolean indicating if job is running, likely by parsing self.job_status"
         raise NotImplementedError("Subclass must provide implementation")
 
-    def state_isunknown(self):
-        "Return boolean indicating if job state retrieval failed because of the resource manager"
-        return None
-
     def state_gethost(self):
         "Return string, hostname or addr of running job, likely by parsing self.job_status"
         raise NotImplementedError("Subclass must provide implementation")
@@ -391,7 +384,7 @@ class BatchSpawnerBase(Spawner):
     async def poll(self):
         """Poll the process"""
         status = await self.query_job_status()
-        if status in (JobStatus.PENDING, JobStatus.RUNNING, JobStatus.UNKNOWN):
+        if status in (JobStatus.PENDING, JobStatus.RUNNING):
             return None
         else:
             self.clear_state()
@@ -426,8 +419,6 @@ class BatchSpawnerBase(Spawner):
                 break
             elif status == JobStatus.PENDING:
                 self.log.debug("Job " + self.job_id + " still pending")
-            elif status == JobStatus.UNKNOWN:
-                self.log.debug("Job " + self.job_id + " still unknown")
             else:
                 self.log.warning(
                     "Job "
@@ -472,7 +463,7 @@ class BatchSpawnerBase(Spawner):
             return
         for i in range(10):
             status = await self.query_job_status()
-            if status not in (JobStatus.RUNNING, JobStatus.UNKNOWN):
+            if status is not JobStatus.RUNNING:
                 return
             await asyncio.sleep(1)
         if self.job_id:
@@ -533,11 +524,6 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
         to obtain the notebook IP.
         See Python docs: re.match.expand""",
     ).tag(config=True)
-    state_unknown_re = Unicode(
-        "",
-        help="Regex that matches job_status if the resource manager is not answering."
-        "Blank indicates not used.",
-    ).tag(config=True)
 
     def state_ispending(self):
         assert self.state_pending_re, "Misconfigured: define state_running_re"
@@ -546,11 +532,6 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
     def state_isrunning(self):
         assert self.state_running_re, "Misconfigured: define state_running_re"
         return self.job_status and re.search(self.state_running_re, self.job_status)
-
-    def state_isunknown(self):
-        # Blank means "not set" and this function always returns None.
-        if self.state_unknown_re:
-            return self.job_status and re.search(self.state_unknown_re, self.job_status)
 
     def state_gethost(self):
         assert self.state_exechost_re, "Misconfigured: define state_exechost_re"
@@ -728,9 +709,6 @@ echo "jupyterhub-singleuser ended gracefully"
     #  RUNNING,  COMPLETING = running
     state_pending_re = Unicode(r"^(?:PENDING|CONFIGURING)").tag(config=True)
     state_running_re = Unicode(r"^(?:RUNNING|COMPLETING)").tag(config=True)
-    state_unknown_re = Unicode(
-        r"^slurm_load_jobs error: (?:Socket timed out on send/recv|Unable to contact slurm controller)"
-    ).tag(config=True)
     state_exechost_re = Unicode(r"\s+((?:[\w_-]+\.?)+)$").tag(config=True)
 
     def parse_job_id(self, output):

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -382,13 +382,17 @@ class BatchSpawnerBase(Spawner):
         raise NotImplementedError("Subclass must provide implementation")
 
     async def poll(self):
-        """Poll the process"""
+        """Poll the process
+
+        Return None if the process is pending or running. If not, clear state
+        and return 0.
+        """
         status = await self.query_job_status()
-        if status in (JobStatus.PENDING, JobStatus.RUNNING):
-            return None
-        else:
+        if not self.job_id:
             self.clear_state()
-            return 1
+            return 0
+        else:
+            return None
 
     startup_poll_interval = Float(
         0.5,

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -207,10 +207,13 @@ class BatchSpawnerBase(Spawner):
         """The command which is substituted inside of the batch script"""
         return " ".join([self.batchspawner_singleuser_cmd] + self.cmd + self.get_args())
 
+    def get_id(self):
+        return id(self)
+
     async def run_command(self, cmd, input=None, env=None):
-        run_cmd_id = get_self_id(self)
+        run_cmd_id = self.get_id()
         self.log.error(f"{run_cmd_id} running command {cmd}")
-        
+
         proc = await asyncio.create_subprocess_shell(
             cmd,
             env=env,
@@ -285,7 +288,7 @@ class BatchSpawnerBase(Spawner):
         self.log.debug("Spawner submitting environment: %s", self.get_env())
         out = await self.run_command(cmd, input=script, env=self.get_env())
         try:
-            run_cmd_id = get_self_id(self)
+            run_cmd_id = self.get_id()
             self.log.info("Job submitted. output: %s", out)
             self.log.error(f"{run_cmd_id} job submitted, output: {out}")
             self.job_id = self.parse_job_id(out)
@@ -469,7 +472,7 @@ class BatchSpawnerBase(Spawner):
         Returns immediately after sending job cancellation command if now=True, otherwise
         tries to confirm that job is no longer running."""
 
-        run_cmd_id = get_self_id(self)
+        run_cmd_id = self.get_id()
         self.log.error(f"{run_cmd_id} stopping server job {self.job_id}")
         self.log.info("Stopping server job " + self.job_id)
         await self.cancel_batch_job()
@@ -569,9 +572,6 @@ class BatchSpawnerRegexStates(BatchSpawnerBase):
             return match.groups()[0]
         else:
             return match.expand(self.state_exechost_exp)
-
-    def get_self_id(self):
-        return id(self)
 
 
 class TorqueSpawner(BatchSpawnerRegexStates):

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -26,8 +26,6 @@ from jinja2 import Template
 from jupyterhub.spawner import Spawner, set_user_setuid
 from traitlets import Dict, Float, Integer, Unicode, default
 
-import random, string
-
 
 def format_template(template, *args, **kwargs):
     """Format a template, either using jinja2 or str.format().
@@ -230,17 +228,23 @@ class BatchSpawnerBase(Spawner):
             out, eout = await proc.communicate(input=inbytes)
         except Exception as e:
             self.log.error(f"{run_cmd_id} Exception {e.__class__.__name__}: {e}")
-            self.log.error(f"{run_cmd_id} exception raised when trying to run command: {cmd}")
+            self.log.error(
+                f"{run_cmd_id} exception raised when trying to run command: {cmd}"
+            )
             proc.kill()
             self.log.error(f"{run_cmd_id} Running command failed, killed process.")
             try:
                 out, eout = await asyncio.wait_for(proc.communicate(), timeout=10)
                 out = out.decode().strip()
                 eout = eout.decode().strip()
-                self.log.error(f"{run_cmd_id} Subprocess returned exitcode {proc.returncode}")
+                self.log.error(
+                    f"{run_cmd_id} Subprocess returned exitcode {proc.returncode}"
+                )
                 self.log.error(f"{run_cmd_id} Stdout: {out}")
                 self.log.error(f"{run_cmd_id} Stderr: {eout}")
-                raise RuntimeError(f"{run_cmd_id} {cmd} exit status {proc.returncode} stdout: {out} stderr: {eout}")
+                raise RuntimeError(
+                    f"{run_cmd_id} {cmd} exit status {proc.returncode} stdout: {out} stderr: {eout}"
+                )
             except TimeoutError:
                 self.log.error(
                     f"{run_cmd_id} Encountered timeout trying to clean up command, process probably killed already: {cmd}"
@@ -425,16 +429,14 @@ class BatchSpawnerBase(Spawner):
         while True:
             status = await self.query_job_status()
             if status == JobStatus.NOTFOUND:
-                self.log.warning(
-                    "Job " + self.job_id + " not found."
-                )
+                self.log.warning("Job " + self.job_id + " not found.")
                 self.clear_state()
                 raise RuntimeError(
                     "The Jupyter batch job has disappeared"
                     " while pending in the queue or died immediately"
                     " after starting."
                 )
-            else: # JobStatus.RUN_OR_PEND
+            else:  # JobStatus.RUN_OR_PEND
                 if self.state_isrunning():
                     break
                 elif self.state_ispending():
@@ -480,7 +482,7 @@ class BatchSpawnerBase(Spawner):
             return
         for i in range(10):
             status = await self.query_job_status()
-            if not status.value: # status.value = 0 (NOTFOUND)
+            if not status.value:  # status.value = 0 (NOTFOUND)
                 return
             await asyncio.sleep(1)
         if self.job_id:
@@ -736,7 +738,9 @@ echo "jupyterhub-singleuser ended gracefully"
     #  RUNNING,  COMPLETING = running
     state_pending_re = Unicode(r"^(?:PENDING|CONFIGURING)").tag(config=True)
     state_running_re = Unicode(r"^(?:RUNNING|COMPLETING)").tag(config=True)
-    state_notfound_re = Unicode(r'slurm_load_jobs error: Invalid job id specified').tag(config=True)
+    state_notfound_re = Unicode(r"slurm_load_jobs error: Invalid job id specified").tag(
+        config=True
+    )
     state_exechost_re = Unicode(r"\s+((?:[\w_-]+\.?)+)$").tag(config=True)
 
     def parse_job_id(self, output):

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -37,6 +37,7 @@ class BatchDummy(BatchSpawnerRegexStates):
     batch_script = Unicode("{cmd}")
     state_pending_re = Unicode("PEND")
     state_running_re = Unicode("RUN")
+    state_notfound_re = Unicode("NOPE")
     state_exechost_re = Unicode("RUN (.*)$")
 
     cmd_expectlist = None
@@ -148,7 +149,7 @@ async def test_submit_pending_fails(db, event_loop):
     """Submission works, but the batch query command immediately fails"""
     spawner = new_spawner(db=db)
     assert spawner.get_state() == {}
-    spawner.batch_query_cmd = "echo xyz"
+    spawner.batch_query_cmd = "echo NOPE"
     with pytest.raises(RuntimeError):
         await asyncio.wait_for(spawner.start(), timeout=30)
     status = await asyncio.wait_for(spawner.query_job_status(), timeout=30)
@@ -485,7 +486,8 @@ normal_slurm_script = [
     (re.compile(r"sudo.*squeue"), "RUNNING " + testhost),  # running
     (re.compile(r"sudo.*squeue"), "RUNNING " + testhost),
     (re.compile(r"sudo.*scancel"), "STOP"),
-    (re.compile(r"sudo.*squeue"), ""),
+    (re.compile(r"sudo.*squeue"), "slurm_load_jobs error: Invalid job id specified'"),
+    (re.compile(r"sudo.*squeue"), "slurm_load_jobs error: Invalid job id specified'"),
 ]
 from .. import SlurmSpawner
 

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -92,7 +92,7 @@ async def test_spawner_start_stop_poll(db, event_loop):
     spawner = new_spawner(db=db)
 
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
     assert spawner.job_id == ""
     assert spawner.get_state() == {}
 
@@ -105,7 +105,7 @@ async def test_spawner_start_stop_poll(db, event_loop):
     spawner.batch_query_cmd = "echo NOPE"
     await asyncio.wait_for(spawner.stop(), timeout=5)
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
     assert spawner.get_state() == {}
 
 
@@ -157,18 +157,18 @@ async def test_submit_pending_fails(db, event_loop):
     assert spawner.job_status == ""
 
 
-async def test_poll_fails(db, event_loop):
-    """Submission works, but a later .poll() fails"""
-    spawner = new_spawner(db=db)
-    assert spawner.get_state() == {}
-    # The start is successful:
-    await asyncio.wait_for(spawner.start(), timeout=30)
-    spawner.batch_query_cmd = "echo xyz"
-    # Now, the poll fails:
-    await asyncio.wait_for(spawner.poll(), timeout=30)
-    # .poll() will run self.clear_state() if it's not found:
-    assert spawner.job_id == ""
-    assert spawner.job_status == ""
+# async def test_poll_fails(db, event_loop):
+#     """Submission works, but a later .poll() fails"""
+#     spawner = new_spawner(db=db)
+#     assert spawner.get_state() == {}
+#     # The start is successful:
+#     await asyncio.wait_for(spawner.start(), timeout=30)
+#     spawner.batch_query_cmd = "echo xyz"
+#     # Now, the poll fails:
+#     await asyncio.wait_for(spawner.poll(), timeout=30)
+#     # .poll() will run self.clear_state() if it's not found:
+#     assert spawner.job_id == ""
+#     assert spawner.job_status == ""
 
 
 async def test_templates(db, event_loop):
@@ -180,7 +180,7 @@ async def test_templates(db, event_loop):
         re.compile(".*RUN"),
     ]
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
     assert spawner.job_id == ""
     assert spawner.get_state() == {}
 
@@ -208,7 +208,7 @@ async def test_templates(db, event_loop):
     ]
     await asyncio.wait_for(spawner.stop(), timeout=5)
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
     assert spawner.get_state() == {}
 
 
@@ -244,7 +244,7 @@ async def test_exec_prefix(db, event_loop):
     spawner = new_spawner(db=db, spawner_class=BatchDummyTestScript)
     # Not running
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
     # Start
     await asyncio.wait_for(spawner.start(), timeout=5)
     assert spawner.job_id == testjob
@@ -255,7 +255,7 @@ async def test_exec_prefix(db, event_loop):
     spawner.batch_query_cmd = "echo NOPE"
     await asyncio.wait_for(spawner.stop(), timeout=5)
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
 
 
 async def run_spawner_script(
@@ -299,7 +299,7 @@ async def run_spawner_script(
     spawner = new_spawner(db=db, spawner_class=BatchDummyTestScript, **spawner_kwargs)
     # Not running at beginning (no command run)
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
     # batch_submit_cmd
     # batch_query_cmd    (result=pending)
     # batch_query_cmd    (result=running)
@@ -313,7 +313,7 @@ async def run_spawner_script(
     await asyncio.wait_for(spawner.stop(), timeout=5)
     # batch_poll_cmd
     status = await asyncio.wait_for(spawner.poll(), timeout=5)
-    assert status == 1
+    assert status == 0
 
 
 async def test_torque(db, event_loop):

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -38,7 +38,6 @@ class BatchDummy(BatchSpawnerRegexStates):
     state_pending_re = Unicode("PEND")
     state_running_re = Unicode("RUN")
     state_exechost_re = Unicode("RUN (.*)$")
-    state_unknown_re = Unicode("UNKNOWN")
 
     cmd_expectlist = None
     out_expectlist = None
@@ -170,21 +169,6 @@ async def test_poll_fails(db, event_loop):
     # .poll() will run self.clear_state() if it's not found:
     assert spawner.job_id == ""
     assert spawner.job_status == ""
-
-
-async def test_unknown_status(db, event_loop):
-    """Polling returns an unknown status"""
-    spawner = new_spawner(db=db)
-    assert spawner.get_state() == {}
-    # The start is successful:
-    await asyncio.wait_for(spawner.start(), timeout=30)
-    spawner.batch_query_cmd = "echo UNKNOWN"
-    # This poll should not fail:
-    await asyncio.wait_for(spawner.poll(), timeout=30)
-    status = await asyncio.wait_for(spawner.query_job_status(), timeout=30)
-    assert status == JobStatus.UNKNOWN
-    assert spawner.job_id == "12345"
-    assert spawner.job_status != ""
 
 
 async def test_templates(db, event_loop):
@@ -498,10 +482,6 @@ async def test_slurm(db, event_loop):
 normal_slurm_script = [
     (re.compile(r"sudo.*sbatch"), str(testjob)),
     (re.compile(r"sudo.*squeue"), "PENDING "),  # pending
-    (
-        re.compile(r"sudo.*squeue"),
-        "slurm_load_jobs error: Unable to contact slurm controller",
-    ),  # unknown
     (re.compile(r"sudo.*squeue"), "RUNNING " + testhost),  # running
     (re.compile(r"sudo.*squeue"), "RUNNING " + testhost),
     (re.compile(r"sudo.*scancel"), "STOP"),


### PR DESCRIPTION
draft PR for anyone interested in this work, possibly related to #314. this removes the "unknown" job status and simplifies the logic in `poll`.

with the project version of the polling logic, we were seeing the hub 'losing track' of batchspawner servers which required manual intervention to delete the users from the hub db in order to clear out the server's bad child state and allow the user to spawn another batch server.

we're been running the version of batchspawner from my branch here for several months now which has addressed the issue; we are no longer seeing this behavior.

I'm opening this PR as a draft since it's incomplete in that:

- there are some debugging server ID logs to clean up
- only some Slurm-related tests have been updated in the branch

I'm not familiar enough with other schedulers to update other tests in the code so this would need some help if the community is interested in upstreaming the work.